### PR TITLE
Rename RBXAssert to RBXASSERT (implementation of #23)

### DIFF
--- a/Client/App/include/util/Debug.h
+++ b/Client/App/include/util/Debug.h
@@ -24,6 +24,8 @@ namespace RBX {
 	} \
 	while (0)
 #define RBXASSERT(expr) SCOPED( (void)( ( RBX::Debugable::assertAction != RBX::Debugable::CrashOnAssert || !!(expr) ) || (RBX::Debugable::doCrash(), 0) ) )
+//temporary redefinition in case this is being implemented while new code is being decompiled.
+#define RBXAssert(expr) RBXASSERT(expr)
 
 template <typename To, typename From>
 To rbx_static_cast(From u)

--- a/Client/App/include/util/Debug.h
+++ b/Client/App/include/util/Debug.h
@@ -24,8 +24,6 @@ namespace RBX {
 	} \
 	while (0)
 #define RBXASSERT(expr) SCOPED( (void)( ( RBX::Debugable::assertAction != RBX::Debugable::CrashOnAssert || !!(expr) ) || (RBX::Debugable::doCrash(), 0) ) )
-//temporary redefinition in case this is being implemented while new code is being decompiled.
-#define RBXAssert(expr) RBXASSERT(expr)
 
 template <typename To, typename From>
 To rbx_static_cast(From u)

--- a/Client/App/include/util/Debug.h
+++ b/Client/App/include/util/Debug.h
@@ -15,19 +15,19 @@ namespace RBX {
 	};
 }
 
-//#define RBXAssert(expr) if ( RBX::Debugable::assertAction == Debugable::CrashOnAssert && !(expr)) RBX::Debugable::doCrash()
+//#define RBXASSERT(expr) if ( RBX::Debugable::assertAction == Debugable::CrashOnAssert && !(expr)) RBX::Debugable::doCrash()
 // copied from assert.h
-//#define RBXAssert(expr) (void)( ( RBX::Debugable::assertAction != RBX::Debugable::CrashOnAssert || !!(expr) ) || (RBX::Debugable::doCrash(), 0) )
+//#define RBXASSERT(expr) (void)( ( RBX::Debugable::assertAction != RBX::Debugable::CrashOnAssert || !!(expr) ) || (RBX::Debugable::doCrash(), 0) )
 #define SCOPED(expr) do \
 	{ \
 		expr; \
 	} \
 	while (0)
-#define RBXAssert(expr) SCOPED( (void)( ( RBX::Debugable::assertAction != RBX::Debugable::CrashOnAssert || !!(expr) ) || (RBX::Debugable::doCrash(), 0) ) )
+#define RBXASSERT(expr) SCOPED( (void)( ( RBX::Debugable::assertAction != RBX::Debugable::CrashOnAssert || !!(expr) ) || (RBX::Debugable::doCrash(), 0) ) )
 
 template <typename To, typename From>
 To rbx_static_cast(From u)
 {
-	RBXAssert(dynamic_cast<To>(u) == static_cast<To>(u));
+	RBXASSERT(dynamic_cast<To>(u) == static_cast<To>(u));
 	return static_cast<To>(u);
 }

--- a/Client/App/include/util/IndexArray.h
+++ b/Client/App/include/util/IndexArray.h
@@ -15,7 +15,7 @@ namespace RBX {
 		public:
 			G3D::Array<tInstance *> array;
 			inline tInstance* operator[](int index){ 
-				RBXAssert(indexOf(array[index]) == index);
+				RBXASSERT(indexOf(array[index]) == index);
 				return array[index]; 
 			}
 
@@ -24,11 +24,11 @@ namespace RBX {
 			// 100% match if G3D::Array<>::find has __declspec(noinline)
 			void fastRemove(tInstance* item)
 			{
-				RBXAssert(array.find(item) != array.end());
+				RBXASSERT(array.find(item) != array.end());
 
 				int removeIndex = indexOf(item);
-				RBXAssert(removeIndex >= 0);
-				RBXAssert(array[removeIndex] == item);
+				RBXASSERT(removeIndex >= 0);
+				RBXASSERT(array[removeIndex] == item);
 
 				// this does something similar to G3D::Array<>::fastRemove
 				tInstance* movedItem = array[size() - 1];
@@ -41,8 +41,8 @@ namespace RBX {
 
 			void fastAppend(tInstance* item)
 			{
-				RBXAssert(item);
-				RBXAssert(indexOf(item) == -1);
+				RBXASSERT(item);
+				RBXASSERT(indexOf(item) == -1);
 				indexOf(item) = array.size();
 				array.append(item);
 			}

--- a/Client/App/include/util/StlExtra.h
+++ b/Client/App/include/util/StlExtra.h
@@ -8,12 +8,12 @@ namespace RBX
 	{
 		std::vector<T>::iterator iter = std::find(vec.begin(), vec.end(), item);
 		unsigned int answer = (unsigned int)std::distance(vec.begin(),iter);
-		RBXAssert(vec[answer] == item);
-		RBXAssert(iter != vec.end());
-		RBXAssert(vec.size() < 32);
+		RBXASSERT(vec[answer] == item);
+		RBXASSERT(iter != vec.end());
+		RBXASSERT(vec.size() < 32);
 		std::vector<T>::iterator vecEnd = vec.end();
 		vecEnd--;
-		RBXAssert(*vecEnd == *(vec.end()-1)); //useless check, in 2013 this either got removed or optimized out
+		RBXASSERT(*vecEnd == *(vec.end()-1)); //useless check, in 2013 this either got removed or optimized out
 		if (iter != vecEnd) {
 			*iter = *vecEnd;
 		}

--- a/Client/App/include/v8kernel/Body.h
+++ b/Client/App/include/v8kernel/Body.h
@@ -33,7 +33,7 @@ namespace RBX {
 			bool validateParentCofmDirty();
 			const G3D::CoordinateFrame& getMeInParent() const
 			{
-				RBXAssert(getParent());
+				RBXASSERT(getParent());
 				return getLink() ? getLink()->getChildInParent() : meInParent;
 			}
 			void updatePV() const;
@@ -134,7 +134,7 @@ namespace RBX {
 			void accumulateForceAtCofm(const G3D::Vector3&);
 			void accumulateForceAtBranchCofm(const G3D::Vector3& force)
 			{
-				RBXAssert(root == this);
+				RBXASSERT(root == this);
 
 				if (root->simBody)
 					root->simBody->accumulateForceCofm(force);

--- a/Client/App/include/v8kernel/IStage.h
+++ b/Client/App/include/v8kernel/IStage.h
@@ -56,11 +56,11 @@ namespace RBX {
 			}
 			virtual void stepWorld(int worldStepId, int uiStepId, bool throttling) //not checked if matching
 			{
-				RBXAssert(downstream);
+				RBXASSERT(downstream);
 				downstream->stepWorld(worldStepId, uiStepId, throttling);
 			}
 			virtual Kernel* getKernel(){
-				RBXAssert(downstream);
+				RBXASSERT(downstream);
 				return downstream->getKernel(); 
 			};
 			RBX::IStage* getDownstream() {return downstream;};

--- a/Client/App/include/v8kernel/KernelData.h
+++ b/Client/App/include/v8kernel/KernelData.h
@@ -10,10 +10,10 @@ namespace RBX {
 		public:
 			KernelData::~KernelData()
 			{
-				RBXAssert(!points.size());
-				RBXAssert(!bodies.size());
-				RBXAssert(!connectors.size());
-				RBXAssert(!connectors2ndPass.size());
+				RBXASSERT(!points.size());
+				RBXASSERT(!bodies.size());
+				RBXASSERT(!connectors.size());
+				RBXASSERT(!connectors2ndPass.size());
 			}
 			IndexArray<Body, &Body::getKernelIndex> bodies;
 			IndexArray<Point, &Point::getKernelIndex> points;

--- a/Client/App/include/v8kernel/KernelIndex.h
+++ b/Client/App/include/v8kernel/KernelIndex.h
@@ -7,7 +7,7 @@ namespace RBX{
 		public:
 			int kernelIndex;
 			KernelIndex::KernelIndex():kernelIndex(-1) {}
-			KernelIndex::~KernelIndex() {RBXAssert(kernelIndex == -1);}
+			KernelIndex::~KernelIndex() {RBXASSERT(kernelIndex == -1);}
 			//virtual void fakeFunc(){};
 
 	};

--- a/Client/App/include/v8world/Assembly.h
+++ b/Client/App/include/v8world/Assembly.h
@@ -57,7 +57,7 @@ namespace RBX
 			bool operator==(const PrimIterator&) const;
 			__forceinline bool operator!=(const PrimIterator& other) const
 			{
-				RBXAssert(clumpIterator == other.clumpIterator);
+				RBXASSERT(clumpIterator == other.clumpIterator);
 				return clumpIterator == other.clumpIterator && primIterator == other.primIterator && assembly == other.assembly;
 			}
 			PrimIterator& operator++();

--- a/Client/App/include/v8world/IPipelined.h
+++ b/Client/App/include/v8world/IPipelined.h
@@ -22,7 +22,7 @@ namespace RBX
 		IPipelined() : currentStage(NULL) {}
 		virtual ~IPipelined()
 		{
-			RBXAssert(currentStage == NULL);
+			RBXASSERT(currentStage == NULL);
 		}
 		void putInPipeline(IStage* stage);
 		void removeFromPipeline(IStage* stage);
@@ -33,28 +33,28 @@ namespace RBX
 		}
 		bool inStage(IStage* iStage) const
 		{
-			RBXAssert(iStage);
-			RBXAssert(currentStage);
+			RBXASSERT(iStage);
+			RBXASSERT(currentStage);
 
 			return currentStage == iStage;
 		}
 		bool inStage(IStage::StageType stageType) const
 		{
-			RBXAssert(currentStage);
+			RBXASSERT(currentStage);
 
 			return currentStage->getStageType() == stageType;
 		}
 		bool inOrDownstreamOfStage(IStage* iStage) const
 		{
-			RBXAssert(iStage);
-			RBXAssert(currentStage);
+			RBXASSERT(iStage);
+			RBXASSERT(currentStage);
 
 			return (int)currentStage->getStageType() >= (int)iStage->getStageType();
 		}
 		bool downstreamOfStage(IStage* iStage) const
 		{
-			RBXAssert(iStage);
-			RBXAssert(currentStage);
+			RBXASSERT(iStage);
+			RBXASSERT(currentStage);
 
 			return (int)currentStage->getStageType() > (int)iStage->getStageType();
 		}

--- a/Client/App/include/v8world/Joint.h
+++ b/Client/App/include/v8world/Joint.h
@@ -51,7 +51,7 @@ namespace RBX
 		virtual void setPrimitive(int i, Primitive* p);
 		virtual JointType getJointType() const
 		{
-			RBXAssert(0);
+			RBXASSERT(0);
 			return NO_JOINT;
 		}
 		virtual bool isBreakable() const
@@ -72,7 +72,7 @@ namespace RBX
 		}
 		virtual G3D::CoordinateFrame align(Primitive* pMove, Primitive* pStay)
 		{
-			RBXAssert(0);
+			RBXASSERT(0);
 			return G3D::CoordinateFrame();
 		}
 		virtual bool canStepUi() const

--- a/Client/App/include/v8world/Mechanism.h
+++ b/Client/App/include/v8world/Mechanism.h
@@ -18,7 +18,7 @@ namespace RBX
 		std::vector<MechanismTracker*> trackers;
 	public:
 		std::list<Mechanism*>::iterator myIt;
-		Mechanism::~Mechanism() { RBXAssert(this->trackers.size() == 0); }
+		Mechanism::~Mechanism() { RBXASSERT(this->trackers.size() == 0); }
 		const std::set<Assembly*>& getAssemblies() const {return assemblies;}
 		std::set<Assembly*>& getAssemblies() {return assemblies;}
 		void notifyMovingPrimitives();

--- a/Client/App/include/v8world/RigidJoint.h
+++ b/Client/App/include/v8world/RigidJoint.h
@@ -9,7 +9,7 @@ namespace RBX
 		// these seem to be the same as Joint
 		virtual Joint::JointType getJointType() const
 		{
-			RBXAssert(0);
+			RBXASSERT(0);
 			return NO_JOINT;
 		}
 		virtual bool isBroken() const

--- a/Client/App/util/Extents.cpp
+++ b/Client/App/util/Extents.cpp
@@ -60,8 +60,8 @@ namespace RBX
 
 	Vector3 Extents::getCorner(int i) const
 	{
-		RBXAssert(i >= 0);
-		RBXAssert(i <= 7);
+		RBXASSERT(i >= 0);
+		RBXASSERT(i <= 7);
 
 		return Vector3(
 			this->low[0 + 3 * (i / 4)],
@@ -111,7 +111,7 @@ namespace RBX
 			v3 = Vector3(this->high.x, this->low.y, this->low.z);
 			break;
 		default:
-			RBXAssert(0);
+			RBXASSERT(0);
 		}
 	}
 
@@ -188,7 +188,7 @@ namespace RBX
 
 	bool Extents::separatedByMoreThan(const Extents& other, float distance) const
 	{
-		RBXAssert(distance > 0.0);
+		RBXASSERT(distance > 0.0);
 
 		Vector3 dv(distance, distance, distance);
 

--- a/Client/App/util/Guid.cpp
+++ b/Client/App/util/Guid.cpp
@@ -33,7 +33,7 @@ namespace RBX
 
 	void Guid::assign(Guid::Data data)
 	{
-		RBXAssert(this->data.scope == localScope);
+		RBXASSERT(this->data.scope == localScope);
 		this->data = data;
 	}
 
@@ -93,7 +93,7 @@ namespace RBX
 			default:
 				if (comparison != 1)
 				{
-					RBXAssert(0);
+					RBXASSERT(0);
 				}
 
 				return false;

--- a/Client/App/util/Math.cpp
+++ b/Client/App/util/Math.cpp
@@ -290,21 +290,21 @@ namespace RBX
 
 	G3D::uint8 rotationToByteBase(float angle)
 	{
-		RBXAssert(angle <= Math::pi());
-		RBXAssert(angle >= -Math::pi());
+		RBXASSERT(angle <= Math::pi());
+		RBXASSERT(angle >= -Math::pi());
 
 		float result = (angle + Math::pi()) / segSizeRadians();
 		int resInt = G3D::iRound(result);
 		
-		RBXAssert(resInt >= -1);
-		RBXAssert(resInt <= 256);
+		RBXASSERT(resInt >= -1);
+		RBXASSERT(resInt <= 256);
 
 		resInt = std::max(0, resInt);
 		resInt = std::min(255, resInt);
 
 		G3D::uint8 byte = (G3D::uint8)resInt;
 
-		RBXAssert(byte <= 255);
+		RBXASSERT(byte <= 255);
 
 		return byte;
 	}

--- a/Client/App/util/Name.cpp
+++ b/Client/App/util/Name.cpp
@@ -48,7 +48,7 @@ namespace RBX
 	{
 		if (!sName)
 		{
-			RBXAssert(dictionaryIndex == -1 || !dictionaryIndex);
+			RBXASSERT(dictionaryIndex == -1 || !dictionaryIndex);
 			return getNullName();
 		}
 
@@ -59,7 +59,7 @@ namespace RBX
 		{
 			if (dictionaryIndex != -1)
 			{
-				RBXAssert(iter->second->dictionaryIndex == dictionaryIndex || iter->second->dictionaryIndex == -1);
+				RBXASSERT(iter->second->dictionaryIndex == dictionaryIndex || iter->second->dictionaryIndex == -1);
 				dictionary()[dictionaryIndex] = iter->second;
 			}
 			return *iter->second;
@@ -75,7 +75,7 @@ namespace RBX
 
 	const Name& Name::lookup(const std::string& sName)
 	{
-		RBXAssert(sName.size() < 50);
+		RBXASSERT(sName.size() < 50);
 		boost::mutex::scoped_lock scoped_lock(mutex());
 
 		NamMap::iterator iter = namMap().find(sName);

--- a/Client/App/util/NormalId.cpp
+++ b/Client/App/util/NormalId.cpp
@@ -56,14 +56,14 @@ namespace RBX
 				return zn_0;
 				}
 		}
-		RBXAssert(0);
+		RBXASSERT(0);
 		return G3D::Vector3::zero();
 	}
 
 	NormalId Vector3ToNormalId(const G3D::Vector3& v)
 	{
 		//the assertion does not match, the rest of the code does
-		RBXAssert((v == Vector3::unitX()) || (v == Vector3::unitY()) || (v == Vector3::unitZ()) || (v == -Vector3::unitX()) || (v == -Vector3::unitY()) || (v == -Vector3::unitZ()));
+		RBXASSERT((v == Vector3::unitX()) || (v == Vector3::unitY()) || (v == Vector3::unitZ()) || (v == -Vector3::unitX()) || (v == -Vector3::unitY()) || (v == -Vector3::unitZ()));
 		if (v.x == 1.0f)
 			return NORM_X;
 		if (v.y == 1.0f)
@@ -76,7 +76,7 @@ namespace RBX
 			return NORM_Y_NEG;
 		if (v.z == -1.0f)
 			return NORM_Z_NEG;
-		RBXAssert(0);
+		RBXASSERT(0);
 		return NORM_UNDEFINED;
 	}
 }

--- a/Client/App/v8kernel/Body.cpp
+++ b/Client/App/v8kernel/Body.cpp
@@ -21,22 +21,22 @@ Body::Body()
 
 Body::~Body()
 {
-	RBXAssert(numChildren() == 0);
+	RBXASSERT(numChildren() == 0);
 	if (parent)
 		setParent(NULL);
-	RBXAssert(!parent);
-	RBXAssert(!link);
-	RBXAssert(index == -1);
-	RBXAssert(simBody);
+	RBXASSERT(!parent);
+	RBXASSERT(!link);
+	RBXASSERT(index == -1);
+	RBXASSERT(simBody);
 	delete simBody;
 	simBody = NULL;
-	RBXAssert(!cofm);
-	RBXAssert(root == this);
+	RBXASSERT(!cofm);
+	RBXASSERT(root == this);
 }
 
 void Body::updatePV() const
 {
-	RBXAssert((parent != NULL) || (getRootConst() == this));
+	RBXASSERT((parent != NULL) || (getRootConst() == this));
 
 	if (parent && this->stateIndex != getRootConst()->getStateIndex())
 	{
@@ -50,7 +50,7 @@ void Body::updatePV() const
 
 void Body::resetRoot(RBX::Body* newRoot)
 {
-	RBXAssert(newRoot == calcRoot());
+	RBXASSERT(newRoot == calcRoot());
 	root = newRoot;
 	for (int i = 0; i < children.size(); i++)
 	{
@@ -80,8 +80,8 @@ void Body::advanceStateIndex()
 
 bool Body::validateParentCofmDirty()
 {
-	RBXAssert(cofm);
-	RBXAssert(cofm->getIsDirty());
+	RBXASSERT(cofm);
+	RBXASSERT(cofm->getIsDirty());
 	if (getParent())
 		getParent()->validateParentCofmDirty();
 	return true;
@@ -96,30 +96,30 @@ void Body::makeCofmDirty()
 		{
 			if (parent)
 				parent->validateParentCofmDirty();
-			RBXAssert(getRootSimBody()->getDirty());
+			RBXASSERT(getRootSimBody()->getDirty());
 		}
 	}
 	else
 	{
 		if (getParent())
 		{
-			RBXAssert(!simBody);
+			RBXASSERT(!simBody);
 			getParent()->makeCofmDirty();
 		}
 		else
 		{
-			RBXAssert(root == this);
+			RBXASSERT(root == this);
 			if (simBody)
 				simBody->makeDirty();
 		}
 		if (cofm)
 		{
 			cofm->makeDirty();
-			RBXAssert(numChildren() > 0);
+			RBXASSERT(numChildren() > 0);
 		}
 		else
 		{
-			RBXAssert(!numChildren());
+			RBXASSERT(!numChildren());
 		}
 	}
 }
@@ -130,14 +130,14 @@ void Body::onChildAdded(RBX::Body* child)
 	children.fastAppend(child);
 	if (!cofm)
 	{
-		RBXAssert(numChildren() == 1);
+		RBXASSERT(numChildren() == 1);
 		cofm = new Cofm(this);
 	}
 }
 
 void Body::onChildRemoved(RBX::Body* child)
 {
-	RBXAssert(cofm);
+	RBXASSERT(cofm);
 	children.fastRemove(child);
 	if (numChildren() == 0)
 	{
@@ -158,8 +158,8 @@ void Body::setMass(float _mass)
 
 void Body::step(float dt, bool throttling)
 {
-	RBXAssert(!getParent());
-	RBXAssert(simBody);
+	RBXASSERT(!getParent());
+	RBXASSERT(simBody);
 
 	if (throttling && canThrottle)
 	{
@@ -187,8 +187,8 @@ void Body::setVelocity(const Velocity& worldVelocity)
 
 void Body::setParent(Body* newParent)
 {
-	RBXAssert(!newParent || newParent->getParent() != this);
-	RBXAssert(newParent != this);
+	RBXASSERT(!newParent || newParent->getParent() != this);
+	RBXASSERT(newParent != this);
 
 	if (parent != newParent)
 	{
@@ -200,14 +200,14 @@ void Body::setParent(Body* newParent)
 
 		if (getParent())
 		{
-			RBXAssert(root == getParent()->getRoot());
-			RBXAssert(!simBody);
+			RBXASSERT(root == getParent()->getRoot());
+			RBXASSERT(!simBody);
 			parent->onChildRemoved(this);
 		}
 		else
 		{
-			RBXAssert(root = this);
-			RBXAssert(simBody);
+			RBXASSERT(root = this);
+			RBXASSERT(simBody);
 			delete simBody;
 			simBody = NULL;
 		}
@@ -242,12 +242,12 @@ G3D::CoordinateFrame Body::getMeInDescendant(const Body* descendant) const
 	}
 	else if (descendant == parent)
 	{
-		RBXAssert(parent);
+		RBXASSERT(parent);
 		return getLink() ? getLink()->getChildInParent() : meInParent;
 	}
 	else
 	{
-		RBXAssert(parent);
+		RBXASSERT(parent);
 		return parent->getMeInDescendant(descendant) * meInParent;
 	}
 }
@@ -256,7 +256,7 @@ void Body::setPv(const PV& _pv)
 {
 	if (parent)
 	{
-		RBXAssert(0);
+		RBXASSERT(0);
 	}
 	else
 	{
@@ -265,11 +265,11 @@ void Body::setPv(const PV& _pv)
 			simBody->makeDirty();
 		advanceStateIndex();
 	}
-	RBXAssert(Math::longestVector3Component(pv.position.translation) < 1000000.0);
-	RBXAssert(Math::isOrthonormal(pv.position.rotation));
-	RBXAssert(!Math::isNanInfDenormVector3(pv.position.translation));
-	RBXAssert(!Math::isNanInfDenormVector3(pv.velocity.linear));
-	RBXAssert(!Math::isNanInfDenormVector3(pv.velocity.rotational));
+	RBXASSERT(Math::longestVector3Component(pv.position.translation) < 1000000.0);
+	RBXASSERT(Math::isOrthonormal(pv.position.rotation));
+	RBXASSERT(!Math::isNanInfDenormVector3(pv.position.translation));
+	RBXASSERT(!Math::isNanInfDenormVector3(pv.velocity.linear));
+	RBXASSERT(!Math::isNanInfDenormVector3(pv.velocity.rotational));
 }
 
 void Body::setCoordinateFrame(const G3D::CoordinateFrame& worldCord)
@@ -280,11 +280,11 @@ void Body::setCoordinateFrame(const G3D::CoordinateFrame& worldCord)
 
 void Body::setMeInParent(const G3D::CoordinateFrame& _meInParent)
 {
-	RBXAssert(Math::longestVector3Component(_meInParent.translation) < 1000000.0);
+	RBXASSERT(Math::longestVector3Component(_meInParent.translation) < 1000000.0);
 
 	if (getLink())
 	{
-		RBXAssert(0);
+		RBXASSERT(0);
 		getLink()->setBody(NULL);
 		link = NULL;
 	}
@@ -297,7 +297,7 @@ void Body::setMeInParent(const G3D::CoordinateFrame& _meInParent)
 	}
 	else
 	{
-		RBXAssert(0);
+		RBXASSERT(0);
 	}
 }
 

--- a/Client/App/v8kernel/Connector.cpp
+++ b/Client/App/v8kernel/Connector.cpp
@@ -5,7 +5,7 @@ namespace RBX
 {
 	void ContactConnector::computeForce(const float dt, bool throttling)
 	{
-		RBXAssert(!throttling || !this->canThrottle());
+		RBXASSERT(!throttling || !this->canThrottle());
 
 		PairParams params;
 		this->geoPair.computeLengthNormalPosition(params);
@@ -80,7 +80,7 @@ namespace RBX
 	{
 		this->point0->accumulateForce(-force);
 		this->point1->accumulateForce(force);
-		RBXAssert(force.magnitude() < Math::inf());
+		RBXASSERT(force.magnitude() < Math::inf());
 	}
 
 	void PointToPointBreakConnector::computeForce(const float dt, bool throttling)

--- a/Client/App/v8kernel/Constants.cpp
+++ b/Client/App/v8kernel/Constants.cpp
@@ -32,8 +32,8 @@ const float Constants::getElasticMultiplier(float elasticity)
 
 const float RBX::Constants::getKmsMaxJointForce(float grid1, float grid2)
 {
-	RBXAssert(std::abs(grid1 * 10.0f - G3D::iRound(grid1 * 10.0f)) < 0.01f);
-	RBXAssert(std::abs(grid2 * 10.0f - G3D::iRound(grid2 * 10.0f)) < 0.01f);
+	RBXASSERT(std::abs(grid1 * 10.0f - G3D::iRound(grid1 * 10.0f)) < 0.01f);
+	RBXASSERT(std::abs(grid2 * 10.0f - G3D::iRound(grid2 * 10.0f)) < 0.01f);
 
 	int grid1int = std::max(1, G3D::iRound(grid1));
 	int grid2int = std::max(1, G3D::iRound(grid2));
@@ -62,15 +62,15 @@ __forceinline Vector3 getClippedSortedSize(const Vector3& v)
 
 const float Constants::getJointKMultiplier(const G3D::Vector3& clippedSortedSize, bool ball)
 {
-	RBXAssert(clippedSortedSize.y >= clippedSortedSize.x);
-	RBXAssert(clippedSortedSize.z >= clippedSortedSize.y);
-	RBXAssert(getClippedSortedSize(clippedSortedSize) == clippedSortedSize);
+	RBXASSERT(clippedSortedSize.y >= clippedSortedSize.x);
+	RBXASSERT(clippedSortedSize.z >= clippedSortedSize.y);
+	RBXASSERT(getClippedSortedSize(clippedSortedSize) == clippedSortedSize);
 
 	Vector3int16 size(clippedSortedSize);
 
 	if (ball)
 	{
-		RBXAssert(size.x >= 1);
+		RBXASSERT(size.x >= 1);
 
 		switch(size.x)
 		{

--- a/Client/App/v8kernel/Kernel.cpp
+++ b/Client/App/v8kernel/Kernel.cpp
@@ -18,7 +18,7 @@ Kernel::Kernel(RBX::IStage* upstream)
 Kernel::~Kernel()
 {
 	Kernel::numKernels--;
-	RBXAssert(!inStepCode);
+	RBXASSERT(!inStepCode);
 	delete kernelData;
 
 }
@@ -30,44 +30,44 @@ void Kernel::insertBody(RBX::Body *b)
 
 inline void Kernel::insertPoint(RBX::Point *p)
 {
-	RBXAssert(!inStepCode);
+	RBXASSERT(!inStepCode);
 	kernelData->points.fastAppend(p);
 }
 
 void Kernel::insertConnector(RBX::Connector *c)
 {
-	RBXAssert(!inStepCode);
+	RBXASSERT(!inStepCode);
 	kernelData->connectors.fastAppend(c);
 }
 
 void Kernel::insertConnector2ndPass(RBX::Connector *c)
 {
-	RBXAssert(!inStepCode);
+	RBXASSERT(!inStepCode);
 	kernelData->connectors2ndPass.fastAppend(c);
 }
 
 void Kernel::removeBody(Body *b) 
 {
-	RBXAssert(!inStepCode);
+	RBXASSERT(!inStepCode);
 	kernelData->bodies.fastRemove(b);
 }
 
 inline void Kernel::removePoint(RBX::Point *p)
 {
-	RBXAssert(!inStepCode);
+	RBXASSERT(!inStepCode);
 	kernelData->points.fastRemove(p);
 }
 
 void Kernel::removeConnector(RBX::Connector *c)
 {
-	RBXAssert(!inStepCode);
+	RBXASSERT(!inStepCode);
 	realTimeConnectors.resize(0, false);
 	kernelData->connectors.fastRemove(c);
 }
 
 void Kernel::removeConnector2ndPass(RBX::Connector *c) 
 {
-	RBXAssert(!inStepCode);
+	RBXASSERT(!inStepCode);
 	kernelData->connectors2ndPass.fastRemove(c);
 }
 
@@ -77,7 +77,7 @@ int Kernel::numConnectors() const { return kernelData->connectors.size(); }
 
 Point* Kernel::newPoint(Body* _body, const G3D::Vector3& worldPos)
 {
-	RBXAssert(!inStepCode);
+	RBXASSERT(!inStepCode);
 	Point* nPoint = new Point(_body);
 
 	nPoint->setWorldPos(worldPos);
@@ -98,7 +98,7 @@ Point* Kernel::newPoint(Body* _body, const G3D::Vector3& worldPos)
 
 void Kernel::deletePoint(RBX::Point* _point)
 {
-	RBXAssert(!inStepCode);
+	RBXASSERT(!inStepCode);
 
 	if (_point) 
 	{
@@ -118,7 +118,7 @@ void Kernel::stepWorld(int worldStepId, int uiStepId, bool throttling)
 	IndexArray<Connector, &Connector::getKernelIndex>& connectors = kernelData->connectors;
 	IndexArray<Connector, &Connector::getKernelIndex>& connectors2ndPass = kernelData->connectors2ndPass;
 
-	RBXAssert(!inStepCode);
+	RBXASSERT(!inStepCode);
 	inStepCode = true;
 	Profiling::Mark mark = Profiling::Mark(*profilingKernel.get(), false);
 	float kernelDt = Constants::kernelDt();

--- a/Client/App/v8kernel/Link.cpp
+++ b/Client/App/v8kernel/Link.cpp
@@ -9,7 +9,7 @@ void Link::dirty()
 {
 	if (body)
 	{
-		RBXAssert(body->getLink() == this);
+		RBXASSERT(body->getLink() == this);
 		body->getRoot()->advanceStateIndex();
 	}
 }

--- a/Client/App/v8kernel/Pair.cpp
+++ b/Client/App/v8kernel/Pair.cpp
@@ -28,7 +28,7 @@ namespace RBX
 	{
 		this->body0->accumulateForce(-_force, _position);
 		this->body1->accumulateForce(_force, _position);
-		RBXAssert(fabs(_force.x) < Math::inf());
+		RBXASSERT(fabs(_force.x) < Math::inf());
 	}
 
 	void GeoPair::computeBallBall(PairParams& _params)

--- a/Client/App/v8kernel/SimBody.cpp
+++ b/Client/App/v8kernel/SimBody.cpp
@@ -33,7 +33,7 @@ __forceinline void SimBody::unkSimInline(float fNum)
 
 void SimBody::update()
 {
-	RBXAssert(dirty);
+	RBXASSERT(dirty);
 	{
 		const G3D::Vector3 cofmOffset = body->getCofmOffset();
 		pv = body->getPV().pvAtLocalOffset(cofmOffset);
@@ -136,7 +136,7 @@ void SimBody::step(float dt)
 
 PV SimBody::getOwnerPV()
 {
-	RBXAssert(!dirty);
+	RBXASSERT(!dirty);
 	G3D::Vector3 cofmOffset = body->getCofmOffset();
 	return pv.pvAtLocalOffset(Vector3(-cofmOffset.x, -cofmOffset.y, -cofmOffset.z));
 }

--- a/Client/App/v8world/Assembly.cpp
+++ b/Client/App/v8world/Assembly.cpp
@@ -17,7 +17,7 @@ namespace RBX
 
 	void Assembly::removeFromKernel()
 	{
-		RBXAssert(getKernel());
+		RBXASSERT(getKernel());
 		rootClump->removeFromKernel(getKernel());
 		IPipelined::removeFromKernel();
 	}
@@ -119,7 +119,7 @@ namespace RBX
 		const std::set<Clump*>& clumps = assembly->getClumps();
 		const std::set<Clump*>::const_iterator start = clumps.begin();
 
-		RBXAssert(start != clumps.end());
+		RBXASSERT(start != clumps.end());
 		Clump* clump = *start;
 
 		return PrimIterator(assembly, start, clump->clumpPrimBegin());
@@ -148,7 +148,7 @@ namespace RBX
 
 	Assembly::PrimIterator& Assembly::PrimIterator::operator++()
 	{
-		RBXAssert(clumpIterator != assembly->getClumps().end());
+		RBXASSERT(clumpIterator != assembly->getClumps().end());
 
 		Clump* clump = *clumpIterator;
 		primIterator++;
@@ -163,7 +163,7 @@ namespace RBX
 			else
 			{
 				primIterator = (*clumpIterator)->clumpPrimBegin();
-				RBXAssert(primIterator != (*clumpIterator)->clumpPrimEnd());
+				RBXASSERT(primIterator != (*clumpIterator)->clumpPrimEnd());
 			}
 		}
 
@@ -187,7 +187,7 @@ namespace RBX
 		typedef std::vector<MotorJoint*>::iterator Iterator;
 		Iterator iter = std::find(motors.begin(), motors.end(), m);
 
-		RBXAssert(iter != motors.end());
+		RBXASSERT(iter != motors.end());
 		motors.erase(iter);
 	}
 
@@ -204,36 +204,36 @@ namespace RBX
 	void Assembly::insertClump(Clump* c)
 	{
 		bool success = clumps.insert(c).second;
-		RBXAssert(success);
+		RBXASSERT(success);
 		c->setAssembly(this);
 	}
 
 	void Assembly::addExternalEdge(Edge* e)
 	{
 		bool success = externalEdges.insert(e).second;
-		RBXAssert(success);
+		RBXASSERT(success);
 	}
 
 	void Assembly::addInternalEdge(Edge* e)
 	{
 		bool success = internalEdges.insert(e).second;
-		RBXAssert(success);
+		RBXASSERT(success);
 	}
 
 	void Assembly::addInconsistentMotor(MotorJoint* m)
 	{
 		bool success = inconsistentMotors.insert(m).second;
-		RBXAssert(success);
+		RBXASSERT(success);
 	}
 
 	Assembly::~Assembly()
 	{
-		RBXAssert(!mechanism);
-		RBXAssert(clumps.empty());
-		RBXAssert(motors.empty());
-		RBXAssert(inconsistentMotors.empty());
-		RBXAssert(externalEdges.empty());
-		RBXAssert(internalEdges.empty());
+		RBXASSERT(!mechanism);
+		RBXASSERT(clumps.empty());
+		RBXASSERT(motors.empty());
+		RBXASSERT(inconsistentMotors.empty());
+		RBXASSERT(externalEdges.empty());
+		RBXASSERT(internalEdges.empty());
 	}
 
 	void Assembly::removeClump(Clump* c)
@@ -244,25 +244,25 @@ namespace RBX
 		c->getRootPrimitive()->getBody()->setParent(NULL);
 
 		size_t removed = clumps.erase(c);
-		RBXAssert(removed == 1);
+		RBXASSERT(removed == 1);
 	}
 
 	void Assembly::removeExternalEdge(Edge* e)
 	{
 		size_t removed = externalEdges.erase(e);
-		RBXAssert(removed == 1);
+		RBXASSERT(removed == 1);
 	}
 
 	void Assembly::removeInternalEdge(Edge* e)
 	{
 		size_t removed = internalEdges.erase(e);
-		RBXAssert(removed == 1);
+		RBXASSERT(removed == 1);
 	}
 
 	void Assembly::removeInconsistentMotor(MotorJoint* m)
 	{
 		size_t removed = inconsistentMotors.erase(m);
-		RBXAssert(removed == 1);
+		RBXASSERT(removed == 1);
 	}
 
 	Assembly::Assembly(Clump* root)
@@ -310,10 +310,10 @@ namespace RBX
 		else
 			other = m->getPrimitive(1);
 
-		RBXAssert(clumps.find(other->getClump()) != clumps.end());
+		RBXASSERT(clumps.find(other->getClump()) != clumps.end());
 
 		c->getRootPrimitive()->getBody()->setParent(other->getBody());
-		RBXAssert(std::find(motors.begin(), motors.end(), m) == motors.end());
+		RBXASSERT(std::find(motors.begin(), motors.end(), m) == motors.end());
 		motors.push_back(m);
 	}
 }

--- a/Client/App/v8world/AssemblyStage.cpp
+++ b/Client/App/v8world/AssemblyStage.cpp
@@ -15,8 +15,8 @@ namespace RBX
 
 	AssemblyStage::~AssemblyStage()
 	{
-		RBXAssert(assemblies.empty());
-		RBXAssert(joints.empty());
+		RBXASSERT(assemblies.empty());
+		RBXASSERT(joints.empty());
 	}
 
 	void AssemblyStage::stepUi(int uiStepId)
@@ -39,13 +39,13 @@ namespace RBX
 	void AssemblyStage::onJointAdded(Joint* j)
 	{
 		bool inserted = joints.insert(j).second;
-		RBXAssert(inserted);
+		RBXASSERT(inserted);
 	}
 
 	void AssemblyStage::onJointRemoving(Joint* j)
 	{
 		size_t removed = joints.erase(j);
-		RBXAssert(removed == 1);
+		RBXASSERT(removed == 1);
 	}
 
 	void AssemblyStage::onEdgeAdded(Edge* e)
@@ -75,7 +75,7 @@ namespace RBX
 		assembly->putInStage(this);
 
 		bool inserted = assemblies.insert(assembly).second;
-		RBXAssert(inserted);
+		RBXASSERT(inserted);
 
 		if (!assembly->getAnchored())
 			rbx_static_cast<CollisionStage*>(getDownstreamWS())->onAssemblyAdded(assembly);
@@ -86,10 +86,10 @@ namespace RBX
 		if (assembly->downstreamOfStage(this))
 			rbx_static_cast<CollisionStage*>(getDownstreamWS())->onAssemblyRemoving(assembly);
 
-		RBXAssert(assembly->inStage(this));
+		RBXASSERT(assembly->inStage(this));
 
 		size_t removed = assemblies.erase(assembly);
-		RBXAssert(removed == 1);
+		RBXASSERT(removed == 1);
 
 		assembly->removeFromStage(this);
 	}

--- a/Client/App/v8world/Block.cpp
+++ b/Client/App/v8world/Block.cpp
@@ -144,7 +144,7 @@ namespace RBX
 			return &this->vertices[Block::BLOCK_FACE_TO_VERTEX[edgeId / 4][edgeId % 4]];
 
 		NormalId faceId = getFaceId(edgeId);
-		RBXAssert(validNormalId(faceId));
+		RBXASSERT(validNormalId(faceId));
 		return &this->vertices[Block::BLOCK_FACE_TO_VERTEX[faceId][edgeId + 1]];
 	}
 
@@ -167,7 +167,7 @@ namespace RBX
 		}
 		else
 		{
-			RBXAssert(clip.z == 0);
+			RBXASSERT(clip.z == 0);
 			normalID = NORM_Z;
 			return &this->vertices[4 * (clip.x <= 0) + 1 + 2 * (clip.y <= 1)];
 		}
@@ -187,7 +187,7 @@ namespace RBX
 		}
 		else
 		{
-			RBXAssert(clip.z != 0);
+			RBXASSERT(clip.z != 0);
 			normalID = clip.z > 0 ? NORM_Z : NORM_Z_NEG;
 			return &this->vertices[(clip.z <= 0)];
 		}
@@ -265,7 +265,7 @@ namespace RBX
 			normalID = NORM_Z_NEG;
 		}
 
-		RBXAssert(best != 1.0e30);
+		RBXASSERT(best != 1.0e30);
 
 		offset = (normalID > NORM_Z) ? this->vertices + 7 /*wtf?*/ : this->vertices;
 
@@ -392,7 +392,7 @@ namespace RBX
 				localHitPoint,
 				inside);
 
-			RBXAssert(!inside);
+			RBXASSERT(!inside);
 			return true;
 		}
 		return result;

--- a/Client/App/v8world/Clump.cpp
+++ b/Client/App/v8world/Clump.cpp
@@ -17,13 +17,13 @@ namespace RBX
 
 		if (body1->getParent() == body0)
 		{
-			RBXAssert(body0->getParent() != body1);
-			RBXAssert(prim0->getClump() == prim1->getClump());
+			RBXASSERT(body0->getParent() != body1);
+			RBXASSERT(prim0->getClump() == prim1->getClump());
 			return prim0;
 		}
 		else if (body0->getParent() == body1)
 		{
-			RBXAssert(prim0->getClump() == prim1->getClump());
+			RBXASSERT(prim0->getClump() == prim1->getClump());
 			return prim1;
 		}
 
@@ -77,15 +77,15 @@ namespace RBX
 
 	void Clump::addAnchor(Anchor* a)
 	{
-		RBXAssert(!anchor);
-		RBXAssert(a->getPrimitive() == rootPrimitive);
+		RBXASSERT(!anchor);
+		RBXASSERT(a->getPrimitive() == rootPrimitive);
 
 		anchor = a;
 	}
 
 	Anchor* Clump::removeAnchor()
 	{
-		RBXAssert(anchor);
+		RBXASSERT(anchor);
 
 		Anchor* a = anchor;
 		anchor = NULL;
@@ -187,28 +187,28 @@ namespace RBX
 	bool Clump::spanningTreeAdjust(RigidJoint* removing)
 	{
 		Primitive* prim = SpanLink::isSpanningJoint(removing);
-		RBXAssert(prim);
+		RBXASSERT(prim);
 
 		Primitive* otherPrim = removing->otherPrimitive(prim);
-		RBXAssert(otherPrim->getClumpDepth() == prim->getClumpDepth() + 1);
+		RBXASSERT(otherPrim->getClumpDepth() == prim->getClumpDepth() + 1);
 
 		SpanLink bestLink = findBestOutsideLink(otherPrim, otherPrim);
 		RigidJoint* joint = bestLink.joint;
 		Primitive* parent = bestLink.parent;
 		if (parent)
 		{
-			RBXAssert(joint != removing);
+			RBXASSERT(joint != removing);
 
 			Primitive* otherPrimLink = joint->otherPrimitive(parent);
-			RBXAssert(inSpanTree(otherPrimLink, prim));
-			RBXAssert(inSpanTree(otherPrimLink, otherPrim));
-			RBXAssert(!inSpanTree(parent, otherPrim));
+			RBXASSERT(inSpanTree(otherPrimLink, prim));
+			RBXASSERT(inSpanTree(otherPrimLink, otherPrim));
+			RBXASSERT(!inSpanTree(parent, otherPrim));
 
 			setSpanParent(otherPrimLink, removing);
 			setParent(otherPrimLink, parent);
 			renumberSpanTree(otherPrimLink);
 
-			RBXAssert(inSpanTree(otherPrim, otherPrimLink));
+			RBXASSERT(inSpanTree(otherPrim, otherPrimLink));
 			
 			return true;
 		}
@@ -218,25 +218,25 @@ namespace RBX
 
 	Body* Clump::getRootBody() const
 	{
-		RBXAssert(primitives.size() > 0);
+		RBXASSERT(primitives.size() > 0);
 		return rootPrimitive->getBody();
 	}
 
 	void Clump::putInKernel(Kernel* kernel)
 	{
-		RBXAssert(!anchor);
+		RBXASSERT(!anchor);
 		return kernel->insertBody(getRootBody());
 	}
 
 	void Clump::removeFromKernel(Kernel* kernel)
 	{
-		RBXAssert(primitives.size() > 0);
+		RBXASSERT(primitives.size() > 0);
 		return kernel->removeBody(getRootBody());
 	}
 
 	void Clump::setSleepStatus(Sim::AssemblyState _set)
 	{
-		RBXAssert(primitives.size() > 0);
+		RBXASSERT(primitives.size() > 0);
 		if (_set != sleepStatus)
 		{
 			if (_set == Sim::AWAKE)
@@ -254,20 +254,20 @@ namespace RBX
 
 	void Clump::addPrimitive(Primitive* p, Primitive* parent, RigidJoint* j)
 	{
-		RBXAssert(!p->getAnchorObject());
-		RBXAssert(!p->getClump());
-		RBXAssert(p->getClumpDepth() == -1);
+		RBXASSERT(!p->getAnchorObject());
+		RBXASSERT(!p->getClump());
+		RBXASSERT(p->getClumpDepth() == -1);
 
 		p->setClump(this);
 		setParent(p, parent);
 		bool success = primitives.insert(p).second;
-		RBXAssert(success);
+		RBXASSERT(success);
 		canSleep = canSleep && p->getCanSleep();
 	}
 
 	void Clump::onPrimitiveCanSleepChanged(Primitive* p)
 	{
-		RBXAssert(containsPrimitive(p));
+		RBXASSERT(containsPrimitive(p));
 		bool primCanSleep = p->getCanSleep();
 		if (primCanSleep)
 		{
@@ -283,7 +283,7 @@ namespace RBX
 
 	bool Clump::calcShouldSleep()
 	{
-		RBXAssert(primitives.size() > 0);
+		RBXASSERT(primitives.size() > 0);
 
 		G3D::CoordinateFrame cofm = rootPrimitive->getBody()->getBranchCofmCoordinateFrame();
 		runningAverageState.update(cofm, MaxRadius);
@@ -293,7 +293,7 @@ namespace RBX
 
 	bool Clump::okNeighborSleep()
 	{
-		RBXAssert(primitives.size() > 0);
+		RBXASSERT(primitives.size() > 0);
 
 		G3D::CoordinateFrame cofm = rootPrimitive->getBody()->getBranchCofmCoordinateFrame();
 		return runningAverageState.withinTolerance(cofm, MaxRadius, 0.02f);
@@ -301,7 +301,7 @@ namespace RBX
 
 	bool Clump::forceNeighborAwake()
 	{
-		RBXAssert(primitives.size() > 0);
+		RBXASSERT(primitives.size() > 0);
 
 		G3D::CoordinateFrame cofm = rootPrimitive->getBody()->getBranchCofmCoordinateFrame();
 		return !runningAverageState.withinTolerance(cofm, MaxRadius, 0.04f);
@@ -323,7 +323,7 @@ namespace RBX
 	void Clump::addInconsistent(RigidJoint* r)
 	{
 		bool success = inconsistentJoints.insert(r).second;
-		RBXAssert(success);
+		RBXASSERT(success);
 	}
 
 	bool Clump::containsInconsistent(RigidJoint* r)
@@ -338,16 +338,16 @@ namespace RBX
 
 	Clump::~Clump()
 	{
-		RBXAssert(!rootPrimitive);
-		RBXAssert(primitives.size() == 0);
-		RBXAssert(inconsistentJoints.size() == 0);
-		RBXAssert(!anchor);
+		RBXASSERT(!rootPrimitive);
+		RBXASSERT(primitives.size() == 0);
+		RBXASSERT(inconsistentJoints.size() == 0);
+		RBXASSERT(!anchor);
 	}
 
 	void Clump::removeInconsistent(RigidJoint* r)
 	{
 		size_t count = inconsistentJoints.erase(r);
-		RBXAssert(count == 1);
+		RBXASSERT(count == 1);
 	}
 
 	void Clump::removePrimitive(Primitive* p)
@@ -361,7 +361,7 @@ namespace RBX
 		p->getBody()->setParent(NULL);
 
 		size_t count = primitives.erase(p);
-		RBXAssert(count == 1);
+		RBXASSERT(count == 1);
 
 		canSleep = computeCanSleep();
 	}
@@ -379,7 +379,7 @@ namespace RBX
 		  inconsistentJoints(),
 		  MaxRadius(this, &Clump::computeMaxRadius)
 	{
-		RBXAssert(root->getClumpDepth() == -1);
+		RBXASSERT(root->getClumpDepth() == -1);
 		primitives.insert(root);
 		root->setClump(this);
 		root->setClumpDepth(0);
@@ -397,7 +397,7 @@ namespace RBX
 	// inling problem with the 2nd deque.push_back prevents matching
 	void Clump::getRigidJoints(std::set<RigidJoint*>& internalRigids, std::set<RigidJoint*>& externalRigids)
 	{
-		RBXAssert(rootPrimitive);
+		RBXASSERT(rootPrimitive);
 
 		std::deque<Primitive*> deque;
 		deque.push_back(rootPrimitive);

--- a/Client/App/v8world/ClumpStage.cpp
+++ b/Client/App/v8world/ClumpStage.cpp
@@ -65,19 +65,19 @@ namespace RBX
 
 		bool inserted;
 		inserted = anchorSizeMap.insert(std::pair<Anchor*, int>(a, size)).second;
-		RBXAssert(inserted);
+		RBXASSERT(inserted);
 
 		inserted = anchors.insert(AnchorEntry(a, size)).second;
-		RBXAssert(inserted);
+		RBXASSERT(inserted);
 	}
 
 	void ClumpStage::rigidTwosInsert(RigidJoint* r)
 	{
-		RBXAssert(!r->getPrimitive(0)->getClump() || !r->getPrimitive(0)->getClump()->containsInconsistent(r));
-		RBXAssert(!r->getPrimitive(1)->getClump() || !r->getPrimitive(1)->getClump()->containsInconsistent(r));
+		RBXASSERT(!r->getPrimitive(0)->getClump() || !r->getPrimitive(0)->getClump()->containsInconsistent(r));
+		RBXASSERT(!r->getPrimitive(1)->getClump() || !r->getPrimitive(1)->getClump()->containsInconsistent(r));
 	
 		bool inserted = rigidTwos.insert(r).second;
-		RBXAssert(inserted);
+		RBXASSERT(inserted);
 	}
 
 	void ClumpStage::rigidOnesInsert(RigidJoint* r)
@@ -91,16 +91,16 @@ namespace RBX
 
 		bool inserted;
 		inserted = rigidJointPowerMap.insert(std::pair<RigidJoint*, PrimitiveSort>(r, sort)).second;
-		RBXAssert(inserted);
+		RBXASSERT(inserted);
 
 		inserted = rigidOnes.insert(RigidEntry(r, sort)).second;
-		RBXAssert(inserted);
+		RBXASSERT(inserted);
 	}
 
 	void ClumpStage::rigidZerosInsert(RigidJoint* r)
 	{
 		bool inserted = rigidZeros.insert(r).second;
-		RBXAssert(inserted);
+		RBXASSERT(inserted);
 	}
 
 	void ClumpStage::primitivesInsert(Primitive* p)
@@ -115,46 +115,46 @@ namespace RBX
 
 		bool inserted;
 		inserted = primitiveSizeMap.insert(std::pair<Primitive*, PrimitiveSort>(p, sort)).second;
-		RBXAssert(inserted);
+		RBXASSERT(inserted);
 
 		inserted = primitives.insert(PrimitiveEntry(p, sort)).second;
-		RBXAssert(inserted);
+		RBXASSERT(inserted);
 	}
 
 	void ClumpStage::motorsInsert(MotorJoint* m)
 	{
-		RBXAssert(!motorsFind(m));
+		RBXASSERT(!motorsFind(m));
 		motors.push_back(m);
 	}
 
 	void ClumpStage::anchoredClumpsInsert(Clump* c)
 	{
 		bool inserted = anchoredClumps.insert(c).second;
-		RBXAssert(inserted);
+		RBXASSERT(inserted);
 	}
 
 	void ClumpStage::freeClumpsInsert(Clump* c)
 	{
 		bool inserted = freeClumps.insert(c).second;
-		RBXAssert(inserted);
+		RBXASSERT(inserted);
 	}
 
 	void ClumpStage::assembliesInsert(Assembly* a)
 	{
 		bool inserted = assemblies.insert(a).second;
-		RBXAssert(inserted);
+		RBXASSERT(inserted);
 	}
 
 	void ClumpStage::edgesInsert(Edge* e)
 	{
 		bool inserted = edges.insert(e).second;
-		RBXAssert(inserted);
+		RBXASSERT(inserted);
 	}
 
 	void ClumpStage::motorAnglesInsert(MotorJoint* m)
 	{
 		bool inserted = motorAngles.insert(m).second;
-		RBXAssert(inserted);
+		RBXASSERT(inserted);
 	}
 
 	bool ClumpStage::anchorsFind(Anchor* a)
@@ -207,7 +207,7 @@ namespace RBX
 		AnchorEntry entry(a, pair.second); 
 
 		size_t removed = anchors.erase(entry);
-		RBXAssert(removed == 1);
+		RBXASSERT(removed == 1);
 
 		anchorSizeMap.erase(it);
 	}
@@ -215,7 +215,7 @@ namespace RBX
 	void ClumpStage::rigidTwosErase(RigidJoint* r)
 	{
 		size_t removed = rigidTwos.erase(r);
-		RBXAssert(removed == 1);
+		RBXASSERT(removed == 1);
 	}
 
 	void ClumpStage::rigidOnesErase(RigidJoint* r)
@@ -228,7 +228,7 @@ namespace RBX
 		RigidEntry entry(r, pair.second); 
 
 		size_t removed = rigidOnes.erase(entry);
-		RBXAssert(removed == 1);
+		RBXASSERT(removed == 1);
 
 		rigidJointPowerMap.erase(it);
 	}
@@ -236,7 +236,7 @@ namespace RBX
 	void ClumpStage::rigidZerosErase(RigidJoint* r)
 	{
 		size_t removed = rigidZeros.erase(r);
-		RBXAssert(removed == 1);
+		RBXASSERT(removed == 1);
 	}
 
 	void ClumpStage::primitivesErase(Primitive* p)
@@ -249,33 +249,33 @@ namespace RBX
 		PrimitiveEntry entry(p, pair.second); 
 
 		size_t removed = primitives.erase(entry);
-		RBXAssert(removed == 1);
+		RBXASSERT(removed == 1);
 
 		primitiveSizeMap.erase(it);
 	}
 
 	void ClumpStage::motorsErase(MotorJoint* m)
 	{
-		RBXAssert(motorsFind(m));
+		RBXASSERT(motorsFind(m));
 		motors.erase(std::find(motors.begin(), motors.end(), m));
 	}
 
 	void ClumpStage::anchoredClumpsErase(Clump* c)
 	{
 		size_t removed = anchoredClumps.erase(c);
-		RBXAssert(removed == 1);
+		RBXASSERT(removed == 1);
 	}
 
 	void ClumpStage::freeClumpsErase(Clump* c)
 	{
 		size_t removed = freeClumps.erase(c);
-		RBXAssert(removed == 1);
+		RBXASSERT(removed == 1);
 	}
 
 	void ClumpStage::motorAnglesErase(MotorJoint* m)
 	{
 		size_t removed = motorAngles.erase(m);
-		RBXAssert(removed == 1);
+		RBXASSERT(removed == 1);
 	}
 
 	__declspec(noinline) bool lessClump(const Clump& c0, const Clump& c1)
@@ -292,7 +292,7 @@ namespace RBX
 	{
 		Clump* clump0 = m->getPrimitive(0)->getClump();
 		Clump* clump1 = m->getPrimitive(1)->getClump();
-		RBXAssert(clump0 && clump1);
+		RBXASSERT(clump0 && clump1);
 
 		if (clump0 == clump1)
 		{
@@ -317,10 +317,10 @@ namespace RBX
 	{
 		Clump* clump0 = r->getPrimitive(0)->getClump();
 		Clump* clump1 = r->getPrimitive(1)->getClump();
-		RBXAssert((clump0 == NULL) != (clump1 == NULL));
+		RBXASSERT((clump0 == NULL) != (clump1 == NULL));
 		if (!clump0)
 			clump0 = clump1;
-		RBXAssert(clump0);
+		RBXASSERT(clump0);
 		return PrimitiveSort(clump0->getRootPrimitive());
 	}
 
@@ -338,13 +338,13 @@ namespace RBX
 
 	void ClumpStage::stepUi(int uiStepId)
 	{
-		RBXAssert(upToDate());
+		RBXASSERT(upToDate());
 		rbx_static_cast<AssemblyStage*>(getDownstreamWS())->stepUi(uiStepId);
 	}
 
 	void ClumpStage::stepWorld(int worldStepId, int uiStepId, bool throttling)
 	{
-		RBXAssert(upToDate());
+		RBXASSERT(upToDate());
 		process();
 
 		AssemblyStage* assemblyStage = rbx_static_cast<AssemblyStage*>(getDownstreamWS());
@@ -379,9 +379,9 @@ namespace RBX
 			}
 			while (!processRigidOnes());
 
-			RBXAssert(anchors.empty());
-			RBXAssert(rigidTwos.empty());
-			RBXAssert(rigidOnes.empty());
+			RBXASSERT(anchors.empty());
+			RBXASSERT(rigidTwos.empty());
+			RBXASSERT(rigidOnes.empty());
 		}
 		while (!processPrimitives());
 		processMotors();
@@ -403,7 +403,7 @@ namespace RBX
 			Primitive* p = a->getPrimitive();
 			bool hasClump = p->getClump() != NULL;
 
-			RBXAssert(hasClump != primitivesFind(p));
+			RBXASSERT(hasClump != primitivesFind(p));
 
 			if (hasClump)
 			{
@@ -428,7 +428,7 @@ namespace RBX
 
 				for (RigidJoint* r = p->getFirstRigid(); r != NULL; r = p->getNextRigid(r))
 				{
-					RBXAssert(inBuffers(r));
+					RBXASSERT(inBuffers(r));
 					removeFromBuffers(r);
 
 					if (c->otherClump(r))
@@ -450,22 +450,22 @@ namespace RBX
 	{
 		while (!rigidTwos.empty())
 		{
-			RBXAssert(!anchors.empty());
+			RBXASSERT(!anchors.empty());
 			RigidJoint* r = *rigidTwos.end();
 
 			Clump* c0 = r->getPrimitive(0)->getClump();
 			Clump* c1 = r->getPrimitive(1)->getClump();
 
-			RBXAssert(!c0 || !c0->containsInconsistent(r));
-			RBXAssert(!c1 || !c1->containsInconsistent(r));
+			RBXASSERT(!c0 || !c0->containsInconsistent(r));
+			RBXASSERT(!c1 || !c1->containsInconsistent(r));
 
 			if (c0 && c0->getAssembly())
 				destroyAssembly(c0->getAssembly());
 			if (c1 && c1->getAssembly())
 				destroyAssembly(c1->getAssembly());
 
-			RBXAssert(!c0 || !c0->containsInconsistent(r));
-			RBXAssert(!c1 || !c1->containsInconsistent(r));
+			RBXASSERT(!c0 || !c0->containsInconsistent(r));
+			RBXASSERT(!c1 || !c1->containsInconsistent(r));
 
 			if (c0 || c1)
 			{
@@ -473,12 +473,12 @@ namespace RBX
 				{
 					rigidOnesInsert(r);
 					rigidTwosErase(r);
-					//RBXAssert(!anchors.empty());
+					//RBXASSERT(!anchors.empty());
 				}
 				else if (c0 == c1)
 				{
 					rigidTwosErase(r);	
-					//RBXAssert(!anchors.empty());
+					//RBXASSERT(!anchors.empty());
 				}
 				else
 				{
@@ -495,12 +495,12 @@ namespace RBX
 					if (!bc->getAnchored())
 					{
 						destroyClump(bc);
-						RBXAssert(!anchors.empty());
+						RBXASSERT(!anchors.empty());
 					}
 					else
 					{
-						RBXAssert(!c0->containsInconsistent(r));
-						RBXAssert(!c1->containsInconsistent(r));
+						RBXASSERT(!c0->containsInconsistent(r));
+						RBXASSERT(!c1->containsInconsistent(r));
 
 						PrimitiveSort power0(c0->getRootPrimitive());
 						PrimitiveSort power1(c1->getRootPrimitive());
@@ -519,7 +519,7 @@ namespace RBX
 							if (bruhClump->size() > 1)
 							{
 								destroyClump(bruhClump);
-								RBXAssert(!rigidOnesFind(r));
+								RBXASSERT(!rigidOnesFind(r));
 
 								return false;
 							}
@@ -533,7 +533,7 @@ namespace RBX
 					}
 				}
 
-				RBXAssert(!anchors.empty());
+				RBXASSERT(!anchors.empty());
 			}
 			else
 			{
@@ -560,7 +560,7 @@ namespace RBX
 			Clump* c0 = r->getPrimitive(0)->getClump();
 			Clump* c1 = r->getPrimitive(1)->getClump();
 
-			RBXAssert(numClumps(r) == 1);
+			RBXASSERT(numClumps(r) == 1);
 
 			Clump* c;
 			if (c0)
@@ -607,7 +607,7 @@ namespace RBX
 				if (other == base)
 				{
 					rigidOnesErase(p1R);
-					RBXAssert(p1R == r);
+					RBXASSERT(p1R == r);
 				}
 				else
 				{
@@ -652,7 +652,7 @@ namespace RBX
 			Primitive* p = (*it).primitive;
 			primitivesErase(p);
 
-			RBXAssert(!p->getClump());
+			RBXASSERT(!p->getClump());
 			Clump* c = new Clump(p);
 			freeClumps.insert(c);
 
@@ -669,7 +669,7 @@ namespace RBX
 			}
 		}
 
-		RBXAssert(rigidZeros.empty());
+		RBXASSERT(rigidZeros.empty());
 		return true;
 	}
 
@@ -694,8 +694,8 @@ namespace RBX
 			for (int i = 0; i < 2; i++)
 			{
 				Primitive* p = m->getPrimitive(i);
-				RBXAssert(p);
-				RBXAssert(p->inStage(this));
+				RBXASSERT(p);
+				RBXASSERT(p->inStage(this));
 
 				Assembly* a = p->getAssembly();
 				if (a && !a->getRootClump()->getAnchored())
@@ -793,7 +793,7 @@ namespace RBX
 		{
 			Assembly* a = *assemblies.begin();
 			size_t removed = assemblies.erase(a);
-			RBXAssert(removed == 1);
+			RBXASSERT(removed == 1);
 			a->putInPipeline(this);
 			rbx_static_cast<AssemblyStage*>(getDownstreamWS())->onAssemblyAdded(a);
 		}
@@ -806,13 +806,13 @@ namespace RBX
 			Edge* e = *edges.begin();
 			edges.erase(edges.begin());
 
-			RBXAssert(e->inStage(this));
+			RBXASSERT(e->inStage(this));
 
 			Assembly* a0 = e->getPrimitive(0)->getAssembly();
 			Assembly* a1 = e->getPrimitive(1)->getAssembly();
 
-			RBXAssert(a0 && a1);
-			RBXAssert(a0->downstreamOfStage(this) && a1->downstreamOfStage(this));
+			RBXASSERT(a0 && a1);
+			RBXASSERT(a0->downstreamOfStage(this) && a1->downstreamOfStage(this));
 
 			if (a0 == a1)
 			{
@@ -838,7 +838,7 @@ namespace RBX
 			MotorJoint* j = *motorAngles.begin();
 			updateMotorJoint(j);
 			size_t removed = motorAngles.erase(j);
-			RBXAssert(removed == 1);
+			RBXASSERT(removed == 1);
 		}
 	}
 
@@ -882,7 +882,7 @@ namespace RBX
 		}
 
 		bool removed = removeFromBuffers(r);
-		RBXAssert(removed);
+		RBXASSERT(removed);
 	}
 
 	void ClumpStage::removeMotor(MotorJoint* m)
@@ -890,7 +890,7 @@ namespace RBX
 		if (!motorsFind(m))
 		{
 			Assembly* a = m->getPrimitive(0)->getAssembly();
-			RBXAssert(a == m->getPrimitive(1)->getAssembly());
+			RBXASSERT(a == m->getPrimitive(1)->getAssembly());
 			destroyAssembly(a);
 		}
 
@@ -908,25 +908,25 @@ namespace RBX
 		{
 			getDownstreamWS()->onEdgeRemoving(e);
 
-			RBXAssert(a0 && a1 && a0 != a1);
+			RBXASSERT(a0 && a1 && a0 != a1);
 			a0->removeExternalEdge(e);
 			a1->removeExternalEdge(e);
 
-			RBXAssert(edges.find(e) == edges.end());
+			RBXASSERT(edges.find(e) == edges.end());
 		}
 		else
 		{
 			size_t removed = edges.erase(e);
 			if (removed != 1)
 			{
-				RBXAssert(a0 && a1);
+				RBXASSERT(a0 && a1);
 				if (a0 == a1)
 				{
 					a0->removeInternalEdge(e);
 				}
 				else
 				{
-					RBXAssert(a0->getAnchored() && a1->getAnchored());
+					RBXASSERT(a0->getAnchored() && a1->getAnchored());
 
 					a0->removeExternalEdge(e);
 					a1->removeExternalEdge(e);
@@ -934,7 +934,7 @@ namespace RBX
 			}
 		}
 
-		RBXAssert(e->inStage(this));
+		RBXASSERT(e->inStage(this));
 	}
 
 	// 100% match if primitivesFind has __forceinline
@@ -948,7 +948,7 @@ namespace RBX
 			}
 			else
 			{
-				RBXAssert(primitivesFind(a->getPrimitive()));
+				RBXASSERT(primitivesFind(a->getPrimitive()));
 			}
 		}
 
@@ -980,7 +980,7 @@ namespace RBX
 		delete c;
 	}
 
-	// 71% match if the numClumps inside of the RBXAssert has __declspec(noinline)
+	// 71% match if the numClumps inside of the RBXASSERT has __declspec(noinline)
 	void ClumpStage::destroyClumpGuts(Clump* c)
 	{
 		typedef std::set<Primitive*>::const_iterator PrimIterator;
@@ -1002,7 +1002,7 @@ namespace RBX
 			RigidJoint* r = *c->getInconsistents().begin();
 
 			Clump* otherClump = c->otherClump(r);
-			RBXAssert(otherClump == c);
+			RBXASSERT(otherClump == c);
 
 			otherClump->removeInconsistent(r);
 			c->removeInconsistent(r);
@@ -1018,7 +1018,7 @@ namespace RBX
 		for (RigidIterator it = internalRs.begin(); it != internalRs.end(); it++)
 		{
 			RigidJoint* r = *it;
-			RBXAssert(r->getPrimitive(0)->getClump() == r->getPrimitive(1)->getClump());
+			RBXASSERT(r->getPrimitive(0)->getClump() == r->getPrimitive(1)->getClump());
 			if (!inBuffers(r))
 				rigidTwosInsert(r);
 		}
@@ -1040,7 +1040,7 @@ namespace RBX
 				}
 			}
 
-			RBXAssert(numClumps(r) < 2);
+			RBXASSERT(numClumps(r) < 2);
 			int count = numClumps(r);
 			if (count != 1)
 				rigidOnesInsert(r);
@@ -1056,7 +1056,7 @@ namespace RBX
 		size_t removed = assemblies.erase(a);
 		if (removed == 0)
 		{
-			RBXAssert(a->downstreamOfStage(this));
+			RBXASSERT(a->downstreamOfStage(this));
 			removeAssemblyEdges(a);
 
 			AssemblyStage* assemblyStage = rbx_static_cast<AssemblyStage*>(getDownstreamWS());
@@ -1064,7 +1064,7 @@ namespace RBX
 		}
 		else
 		{
-			RBXAssert(a->inStage(this));
+			RBXASSERT(a->inStage(this));
 		}
 
 		while (!a->getMotors().empty())
@@ -1100,19 +1100,19 @@ namespace RBX
 				freeClumpsInsert(c);
 		}
 
-		RBXAssert(a->inStage(this));
+		RBXASSERT(a->inStage(this));
 		a->removeFromPipeline(this);
 		delete a;
 	}
 
-	// 100% match if downstreamOfStage in RBXAssert has __forceinline
+	// 100% match if downstreamOfStage in RBXASSERT has __forceinline
 	void ClumpStage::removeExternalEdge(Edge* e)
 	{
 		Assembly* a0 = e->getPrimitive(0)->getAssembly();
 		Assembly* a1 = e->getPrimitive(1)->getAssembly();
 
-		RBXAssert(e->downstreamOfStage(this) != (a0->getAnchored() && a1->getAnchored()));
-		RBXAssert(!edgesFind(e));
+		RBXASSERT(e->downstreamOfStage(this) != (a0->getAnchored() && a1->getAnchored()));
+		RBXASSERT(!edgesFind(e));
 
 		a0->removeExternalEdge(e);
 		a1->removeExternalEdge(e);
@@ -1124,9 +1124,9 @@ namespace RBX
 
 	void ClumpStage::removeInternalEdge(Edge* e)
 	{
-		RBXAssert(e->inStage(this));
-		RBXAssert(!edgesFind(e));
-		RBXAssert(e->getPrimitive(0)->getAssembly() == e->getPrimitive(1)->getAssembly());
+		RBXASSERT(e->inStage(this));
+		RBXASSERT(!edgesFind(e));
+		RBXASSERT(e->getPrimitive(0)->getAssembly() == e->getPrimitive(1)->getAssembly());
 
 		e->getPrimitive(0)->getAssembly()->removeInternalEdge(e);
 		edgesInsert(e);
@@ -1147,7 +1147,7 @@ namespace RBX
 
 	void ClumpStage::onPrimitiveAdded(Primitive* p)
 	{
-		RBXAssert(!p->getFirstEdge());
+		RBXASSERT(!p->getFirstEdge());
 		p->putInStage(this);
 		primitivesInsert(p);
 		if (p->getAnchorObject())
@@ -1175,8 +1175,8 @@ namespace RBX
 	// 100% match if inOrDownstreamOfStage has __forceinline
 	void ClumpStage::onEdgeAdded(Edge* e)
 	{
-		RBXAssert(e->getPrimitive(0)->inOrDownstreamOfStage(this));
-		RBXAssert(e->getPrimitive(1)->inOrDownstreamOfStage(this));
+		RBXASSERT(e->getPrimitive(0)->inOrDownstreamOfStage(this));
+		RBXASSERT(e->getPrimitive(1)->inOrDownstreamOfStage(this));
 
 		Primitive::insertEdge(e);
 		e->putInStage(this);
@@ -1197,8 +1197,8 @@ namespace RBX
 	// 100% match if inOrDownstreamOfStage has __forceinline
 	void ClumpStage::onEdgeRemoving(Edge* e)
 	{
-		RBXAssert(e->getPrimitive(0)->inOrDownstreamOfStage(this));
-		RBXAssert(e->getPrimitive(1)->inOrDownstreamOfStage(this));
+		RBXASSERT(e->getPrimitive(0)->inOrDownstreamOfStage(this));
+		RBXASSERT(e->getPrimitive(1)->inOrDownstreamOfStage(this));
 
 		if (RigidJoint::isRigidJoint(e))
 		{
@@ -1221,7 +1221,7 @@ namespace RBX
 		process();
 
 		Assembly* a = p->getAssembly();
-		RBXAssert(a);
+		RBXASSERT(a);
 
 		bool canSleep = a->getCanSleep();
 		a->onPrimitiveCanSleepChanged(p);
@@ -1242,7 +1242,7 @@ namespace RBX
 
 	void ClumpStage::onMotorAngleChanged(MotorJoint* m)
 	{
-		RBXAssert(motorsFind(m) || (m->getPrimitive(0)->getAssembly() && m->getPrimitive(1)->getAssembly()));
+		RBXASSERT(motorsFind(m) || (m->getPrimitive(0)->getAssembly() && m->getPrimitive(1)->getAssembly()));
 
 		if (!motorAnglesFind(m))
 			motorAnglesInsert(m);
@@ -1250,9 +1250,9 @@ namespace RBX
 
 	void ClumpStage::updateMotorJoint(MotorJoint* m)
 	{
-		RBXAssert(m->getPrimitive(0)->getAssembly());
-		RBXAssert(m->getPrimitive(1)->getAssembly());
-		RBXAssert(!motorsFind(m));
+		RBXASSERT(m->getPrimitive(0)->getAssembly());
+		RBXASSERT(m->getPrimitive(1)->getAssembly());
+		RBXASSERT(!motorsFind(m));
 
 		Primitive* p0 = m->getPrimitive(0);
 		Primitive* p1 = !p0->getClump()->getRootPrimitive()->getBody()->getParent() ? m->getPrimitive(1) : p0;
@@ -1260,7 +1260,7 @@ namespace RBX
 			p0 = m->getPrimitive(1);
 
 		Primitive* p1Root = p1->getClump()->getRootPrimitive();
-		RBXAssert(p1Root->getBody()->getParent() == p0->getBody());
+		RBXASSERT(p1Root->getBody()->getParent() == p0->getBody());
 
 		G3D::CoordinateFrame mChildInMParent = m->getMeInOther(p1);
 		if (p1 == p1Root)
@@ -1291,7 +1291,7 @@ namespace RBX
 	void ClumpStage::removeFromAssemblyFast(Primitive* p)
 	{
 		Assembly* a = p->getAssembly();
-		RBXAssert(a);
+		RBXASSERT(a);
 
 		Edge* e = p->getFirstEdge();
 
@@ -1330,7 +1330,7 @@ namespace RBX
 		{
 			if (c->containsInconsistent(r))
 			{
-				RBXAssert(!inBuffers(r));
+				RBXASSERT(!inBuffers(r));
 				c->removeInconsistent(r);
 				c->otherClump(r)->removeInconsistent(r);
 			}

--- a/Client/App/v8world/CollisionStage.cpp
+++ b/Client/App/v8world/CollisionStage.cpp
@@ -20,13 +20,13 @@ namespace RBX
 
 	CollisionStage::~CollisionStage()
 	{
-		RBXAssert(stepping.size() == 0);
-		RBXAssert(numContactsInStage == 0);
+		RBXASSERT(stepping.size() == 0);
+		RBXASSERT(numContactsInStage == 0);
 	}
 
 	void CollisionStage::removeContact(Contact* c)
 	{
-		RBXAssert(c->inOrDownstreamOfStage(this));
+		RBXASSERT(c->inOrDownstreamOfStage(this));
 		if (c->downstreamOfStage(this))
 			removeContactFromDownstreamStage(c);
 
@@ -59,7 +59,7 @@ namespace RBX
 			{
 				Contact* c = stepping[i];
 
-				RBXAssert(c->inStage(this));
+				RBXASSERT(c->inStage(this));
 				if (!throttling || !c->getPrimitive(0)->getBody()->getCanThrottle() || !c->getPrimitive(1)->getBody()->getCanThrottle())
 				{
 					bool okToStep;
@@ -74,7 +74,7 @@ namespace RBX
 						{
 							toErase.push_back(c);
 							getDownstreamWS()->onEdgeAdded(c);
-							RBXAssert(c->downstreamOfStage(this));
+							RBXASSERT(c->downstreamOfStage(this));
 						}
 					}
 				}
@@ -110,23 +110,23 @@ namespace RBX
 		for (int i = 0; i < separating.size(); ++i)
 		{
 			Contact* c = separating[i];
-			RBXAssert(!c->downstreamOfStage(this));
-			RBXAssert(c->inStage(this));
+			RBXASSERT(!c->downstreamOfStage(this));
+			RBXASSERT(c->inStage(this));
 			updateContact(c);
 		}
 	}
 
 	void CollisionStage::removeContactFromDownstreamStage(Contact* c)
 	{
-		RBXAssert(c->downstreamOfStage(this));
-		RBXAssert(c->steppingIndexFunc() < 0);
+		RBXASSERT(c->downstreamOfStage(this));
+		RBXASSERT(c->steppingIndexFunc() < 0);
 
 		getDownstreamWS()->onEdgeRemoving(c);
 	}
 
 	void CollisionStage::updateContact(Contact* c)
 	{
-		RBXAssert(c->inOrDownstreamOfStage(this));
+		RBXASSERT(c->inOrDownstreamOfStage(this));
 		if (c->downstreamOfStage(this))
 		{
 			bool temp;
@@ -136,7 +136,7 @@ namespace RBX
 			removeContactFromDownstreamStage(c);
 		}
 
-		RBXAssert(c->inStage(this));
+		RBXASSERT(c->inStage(this));
 
 		if (c->steppingIndexFunc() < 0)
 			stepping.fastAppend(c);
@@ -144,7 +144,7 @@ namespace RBX
 
 	void CollisionStage::onJointAdded(Joint* j)
 	{
-		RBXAssert(!j->inKernel());
+		RBXASSERT(!j->inKernel());
 		getDownstreamWS()->onEdgeAdded(j);
 
 		Contact* c = Primitive::getContact(j->getPrimitive(0), j->getPrimitive(1));
@@ -156,7 +156,7 @@ namespace RBX
 	{
 		Contact* c = Primitive::getContact(j->getPrimitive(0), j->getPrimitive(1));
 		if (c && c->inOrDownstreamOfStage(this))
-			RBXAssert(c->inStage(this));
+			RBXASSERT(c->inStage(this));
 
 		getDownstreamWS()->onEdgeRemoving(j);
 
@@ -173,16 +173,16 @@ namespace RBX
 
 	void CollisionStage::onEdgeAdded(Edge* e)
 	{
-		RBXAssert(!e->inKernel());
-		RBXAssert(!e->inOrDownstreamOfStage(this));
-		RBXAssert(isAssemblyInOrDownstreamOfStage(e, this));
+		RBXASSERT(!e->inKernel());
+		RBXASSERT(!e->inOrDownstreamOfStage(this));
+		RBXASSERT(isAssemblyInOrDownstreamOfStage(e, this));
 
 		e->putInStage(this);
 		if (e->getEdgeType() == Edge::CONTACT)
 		{
 			++numContactsInStage;
 			Contact* c = rbx_static_cast<Contact*>(e);
-			RBXAssert(c->steppingIndexFunc() < 0);
+			RBXASSERT(c->steppingIndexFunc() < 0);
 			updateContact(c);
 		}
 		else
@@ -194,8 +194,8 @@ namespace RBX
 
 	void CollisionStage::onEdgeRemoving(Edge* e)
 	{
-		RBXAssert(isAssemblyInOrDownstreamOfStage(e, this));
-		RBXAssert(e->inOrDownstreamOfStage(this));
+		RBXASSERT(isAssemblyInOrDownstreamOfStage(e, this));
+		RBXASSERT(e->inOrDownstreamOfStage(this));
 
 		if (e->getEdgeType() == Edge::CONTACT)
 		{
@@ -210,7 +210,7 @@ namespace RBX
 		}
 
 		e->removeFromStage(this);
-		RBXAssert(!e->inOrDownstreamOfStage(this));
+		RBXASSERT(!e->inOrDownstreamOfStage(this));
 	}
 
 	void CollisionStage::onPrimitiveCanCollideChanged(Primitive* p)

--- a/Client/App/v8world/Edge.cpp
+++ b/Client/App/v8world/Edge.cpp
@@ -15,7 +15,7 @@ namespace RBX
 
 	void Edge::setPrimitive(int i, Primitive* p)
 	{
-		RBXAssert((i == 0) || (i == 1));
+		RBXASSERT((i == 0) || (i == 1));
 
 		if (i == 0)
 			prim0 = p;

--- a/Client/App/v8world/IMoving.cpp
+++ b/Client/App/v8world/IMoving.cpp
@@ -15,7 +15,7 @@ namespace RBX
 
 	void IMoving::makeMoving()
 	{
-		RBXAssert(stepsToSleep > 0);
+		RBXASSERT(stepsToSleep > 0);
 		onCanAggregateChanged(false);
 		if (iMovingManager)
 		{
@@ -38,7 +38,7 @@ namespace RBX
 
 	bool IMoving::checkSleep()
 	{
-		RBXAssert(stepsToSleep > 0);
+		RBXASSERT(stepsToSleep > 0);
 		
 		if (stepsToSleep > 1)
 		{
@@ -46,7 +46,7 @@ namespace RBX
 			return false;
 		}
 
-		RBXAssert(stepsToSleep == 1);
+		RBXASSERT(stepsToSleep == 1);
 		stepsToSleep = 0;
 		onCanAggregateChanged(false);
 		return true;
@@ -77,8 +77,8 @@ namespace RBX
 
 	IMovingManager::~IMovingManager()
 	{
-		RBXAssert(current == moving.end());
-		RBXAssert(moving.empty());
+		RBXASSERT(current == moving.end());
+		RBXASSERT(moving.empty());
 	}
 
 	void IMovingManager::remove(IMoving* iMoving)
@@ -96,7 +96,7 @@ namespace RBX
 
 	void IMovingManager::onMovingHeartbeat()
 	{
-		RBXAssert(current == moving.end());
+		RBXASSERT(current == moving.end());
 
 		current = moving.begin();
 		while (current != moving.end())

--- a/Client/App/v8world/IPipelined.cpp
+++ b/Client/App/v8world/IPipelined.cpp
@@ -5,7 +5,7 @@ namespace RBX
 {
 	IStage* IPipelined::getStage(IStage::StageType stageType) const
 	{
-		RBXAssert(currentStage);
+		RBXASSERT(currentStage);
 
 		IStage* stage = currentStage;
 		while (stage->getStageType() != stageType)
@@ -20,44 +20,44 @@ namespace RBX
 
 	void IPipelined::putInPipeline(IStage* stage)
 	{
-		RBXAssert(stage);
-		RBXAssert(!currentStage);
+		RBXASSERT(stage);
+		RBXASSERT(!currentStage);
 
 		currentStage = stage;
 	}
 
 	void IPipelined::removeFromPipeline(IStage* stage)
 	{
-		RBXAssert(stage);
-		RBXAssert(currentStage);
-		RBXAssert(currentStage == stage);
+		RBXASSERT(stage);
+		RBXASSERT(currentStage);
+		RBXASSERT(currentStage == stage);
 
 		currentStage = NULL;
 	}
 
 	void IPipelined::putInStage(IStage* stage)
 	{
-		RBXAssert(stage);
-		RBXAssert(currentStage);
-		RBXAssert(stage->getUpstream() == currentStage);
-		RBXAssert(currentStage->getDownstream() == stage);
+		RBXASSERT(stage);
+		RBXASSERT(currentStage);
+		RBXASSERT(stage->getUpstream() == currentStage);
+		RBXASSERT(currentStage->getDownstream() == stage);
 
 		currentStage = stage;
 	}
 
 	void IPipelined::removeFromStage(IStage* stage)
 	{
-		RBXAssert(currentStage);
-		RBXAssert(stage);
-		RBXAssert(stage == currentStage);
-		RBXAssert(stage->getUpstream());
+		RBXASSERT(currentStage);
+		RBXASSERT(stage);
+		RBXASSERT(stage == currentStage);
+		RBXASSERT(stage->getUpstream());
 
 		currentStage = currentStage->getUpstream();
 	}
 
 	Kernel* IPipelined::getKernel() const
 	{
-		RBXAssert(this->inKernel());
+		RBXASSERT(this->inKernel());
 
 		IStage* stage = this->getStage(IStage::KERNEL_STAGE);
 		return rbx_static_cast<Kernel*>(stage);
@@ -70,8 +70,8 @@ namespace RBX
 
 	void IPipelined::removeFromKernel()
 	{
-		RBXAssert(currentStage);
-		RBXAssert(currentStage->getStageType() == IStage::KERNEL_STAGE);
+		RBXASSERT(currentStage);
+		RBXASSERT(currentStage->getStageType() == IStage::KERNEL_STAGE);
 
 		this->removeFromStage(currentStage);
 	}

--- a/Client/App/v8world/IWorldStage.cpp
+++ b/Client/App/v8world/IWorldStage.cpp
@@ -5,21 +5,21 @@ namespace RBX
 {
 	void IWorldStage::onEdgeAdded(Edge* e)
 	{
-		RBXAssert(getDownstreamWS());
+		RBXASSERT(getDownstreamWS());
 		e->putInPipeline(this);
 		getDownstreamWS()->onEdgeAdded(e);
 	}
 
 	void IWorldStage::onEdgeRemoving(Edge* e)
 	{
-		RBXAssert(getDownstreamWS());
+		RBXASSERT(getDownstreamWS());
 		getDownstreamWS()->onEdgeRemoving(e);
 		e->removeFromStage(this);
 	}
 
 	int IWorldStage::getMetric(MetricType metricType)
 	{
-		RBXAssert(getDownstreamWS());
+		RBXASSERT(getDownstreamWS());
 		return getDownstreamWS()->getMetric(metricType);
 	}
 }

--- a/Client/App/v8world/Joint.cpp
+++ b/Client/App/v8world/Joint.cpp
@@ -26,13 +26,13 @@ namespace RBX
 		  jointCoord0(),
 		  jointCoord1()
 	{
-		RBXAssert(jointCoord0 == CoordinateFrame());
-		RBXAssert(jointCoord1 == CoordinateFrame());
+		RBXASSERT(jointCoord0 == CoordinateFrame());
+		RBXASSERT(jointCoord1 == CoordinateFrame());
 	}
 
 	Joint::~Joint()
 	{
-		RBXAssert(!jointOwner);
+		RBXASSERT(!jointOwner);
 	}
 
 	void Joint::setPrimitive(int i, Primitive* p)
@@ -50,7 +50,7 @@ namespace RBX
 
 	void Joint::setJointOwner(IJointOwner* value)
 	{
-		RBXAssert((value == NULL) != (jointOwner == NULL));
+		RBXASSERT((value == NULL) != (jointOwner == NULL));
 		jointOwner = value;
 	}
 

--- a/Client/App/v8world/JointStage.cpp
+++ b/Client/App/v8world/JointStage.cpp
@@ -24,7 +24,7 @@ namespace RBX
 
 	void JointStage::moveEdgeToDownstream(Edge* e)
 	{
-		RBXAssert(edgeHasPrimitivesDownstream(e));
+		RBXASSERT(edgeHasPrimitivesDownstream(e));
 
 		IStage* downstream = getDownstream();
 		ClumpStage* clumpStage = rbx_static_cast<ClumpStage*>(downstream);
@@ -33,7 +33,7 @@ namespace RBX
 
 	void JointStage::removeEdgeFromDownstream(Edge* e)
 	{
-		RBXAssert(edgeHasPrimitivesDownstream(e));
+		RBXASSERT(edgeHasPrimitivesDownstream(e));
 
 		IStage* downstream = getDownstream();
 		ClumpStage* clumpStage = rbx_static_cast<ClumpStage*>(downstream);
@@ -60,7 +60,7 @@ namespace RBX
 		if (!p)
 			return;
 
-		RBXAssert(!pairInMap(j, p));
+		RBXASSERT(!pairInMap(j, p));
 		jointMap.insert(std::pair<Primitive*, Joint*>(p, j));
 	}
 
@@ -68,7 +68,7 @@ namespace RBX
 	{
 		// TODO
 		// remove noinline once completed
-		RBXAssert(0);
+		RBXASSERT(0);
 	}
 
 	// NOTE: might be in headers
@@ -80,67 +80,67 @@ namespace RBX
 	void JointStage::removeFromList(Joint* j)
 	{
 		size_t count = incompleteJoints.erase(j);
-		RBXAssert(count == 1);
+		RBXASSERT(count == 1);
 	}
 
 	void JointStage::insertToList(Joint* j)
 	{
 		std::pair<std::set<Joint*>::iterator, bool> result = incompleteJoints.insert(j);
-		RBXAssert(result.second);
+		RBXASSERT(result.second);
 	}
 
 	void JointStage::moveJointToDownstream(Joint* j)
 	{
-		RBXAssert(!jointInList(j));
-		RBXAssert(!pairInMap(j, j->getPrimitive(0)));
-		RBXAssert(!pairInMap(j, j->getPrimitive(1)));
+		RBXASSERT(!jointInList(j));
+		RBXASSERT(!pairInMap(j, j->getPrimitive(0)));
+		RBXASSERT(!pairInMap(j, j->getPrimitive(1)));
 
 		moveEdgeToDownstream(j);
 	}
 
 	void JointStage::removeJointFromDownstream(Joint* j)
 	{
-		RBXAssert(!jointInList(j));
-		RBXAssert(!pairInMap(j, j->getPrimitive(0)));
-		RBXAssert(!pairInMap(j, j->getPrimitive(1)));
+		RBXASSERT(!jointInList(j));
+		RBXASSERT(!pairInMap(j, j->getPrimitive(0)));
+		RBXASSERT(!pairInMap(j, j->getPrimitive(1)));
 
 		removeEdgeFromDownstream(j);
 	}
 
 	void JointStage::onJointPrimitiveNulling(Joint* j, Primitive* nulling)
 	{
-		RBXAssert(!nulling);
-		RBXAssert(!j->links(nulling));
-		RBXAssert(j->downstreamOfStage(this) == edgeHasPrimitivesDownstream(j));
-		RBXAssert(j->downstreamOfStage(this) != edgeHasPrimitivesDownstream(j));
+		RBXASSERT(!nulling);
+		RBXASSERT(!j->links(nulling));
+		RBXASSERT(j->downstreamOfStage(this) == edgeHasPrimitivesDownstream(j));
+		RBXASSERT(j->downstreamOfStage(this) != edgeHasPrimitivesDownstream(j));
 
 		if (j->downstreamOfStage(this))
 		{
-			RBXAssert(!pairInMap(j, nulling));
+			RBXASSERT(!pairInMap(j, nulling));
 			removeJointFromDownstream(j);
 			insertToList(j);
 			insertToMap(j, j->otherPrimitive(nulling));
 		}
 		else
 		{
-			RBXAssert(!j->inStage(this));
+			RBXASSERT(!j->inStage(this));
 			removeFromMap(j, nulling);
 		}
 
-		RBXAssert(!pairInMap(j, nulling));
+		RBXASSERT(!pairInMap(j, nulling));
 	}
 
 	void JointStage::onJointPrimitiveSet(Joint* j, Primitive* p)
 	{
-		RBXAssert(!p);
-		RBXAssert(!j->links(p));
-		RBXAssert(j->inStage(this));
-		RBXAssert(!jointInList(j));
+		RBXASSERT(!p);
+		RBXASSERT(!j->links(p));
+		RBXASSERT(j->inStage(this));
+		RBXASSERT(!jointInList(j));
 
 		if (edgeHasPrimitivesDownstream(j))
 		{
-			RBXAssert(!pairInMap(j, p));
-			RBXAssert(pairInMap(j, j->otherPrimitive(p)));
+			RBXASSERT(!pairInMap(j, p));
+			RBXASSERT(pairInMap(j, j->otherPrimitive(p)));
 
 			removeFromList(j);
 			removeFromMap(j, j->otherPrimitive(p));

--- a/Client/App/v8world/Mechanism.cpp
+++ b/Client/App/v8world/Mechanism.cpp
@@ -28,17 +28,17 @@ namespace RBX
 
 	void Mechanism::insertAssembly(Assembly* a)
 	{
-		RBXAssert(!a->getMechanism());
+		RBXASSERT(!a->getMechanism());
 		bool success = this->getAssemblies().insert(a).second;
-		RBXAssert(success);
+		RBXASSERT(success);
 		a->setMechanism(this);
 	}
 
 	void Mechanism::removeAssembly(Assembly* a)
 	{
-		RBXAssert(a->getMechanism() == this);
+		RBXASSERT(a->getMechanism() == this);
 		size_t count = this->getAssemblies().erase(a);
-		RBXAssert(count == 1);
+		RBXASSERT(count == 1);
 		a->setMechanism(NULL);
 	}
 
@@ -61,7 +61,7 @@ namespace RBX
 	{
 		if (this->mechanism)
 		{
-			RBXAssert(this->containedBy(this->mechanism));
+			RBXASSERT(this->containedBy(this->mechanism));
 			return true;
 		}
 		return false;
@@ -71,17 +71,17 @@ namespace RBX
 	{
 		if (this->mechanism)
 		{
-			RBXAssert(this->containedBy(this->mechanism));
+			RBXASSERT(this->containedBy(this->mechanism));
 			fastRemoveShort<MechanismTracker*>(this->mechanism->trackers, this);
-			RBXAssert(!this->containedBy(this->mechanism));
+			RBXASSERT(!this->containedBy(this->mechanism));
 			this->mechanism = NULL;
 		}
 	}
 
 	Mechanism* MechanismTracker::getMechanism()
 	{
-		RBXAssert(this->mechanism);
-		RBXAssert(this->containedBy(this->mechanism));
+		RBXASSERT(this->mechanism);
+		RBXASSERT(this->containedBy(this->mechanism));
 		return this->mechanism;
 	}
 
@@ -90,17 +90,17 @@ namespace RBX
 		this->stopTracking();
 		if (m)
 		{
-			RBXAssert(!this->containedBy(m));
+			RBXASSERT(!this->containedBy(m));
 			m->trackers.push_back(this);
-			RBXAssert(this->containedBy(m));
+			RBXASSERT(this->containedBy(m));
 			this->mechanism = m;
 		}
 	}
 
 	void MechanismTracker::transferTrackers(Mechanism* from, Mechanism* to)
 	{
-		RBXAssert(from);
-		RBXAssert(from != to);
+		RBXASSERT(from);
+		RBXASSERT(from != to);
 
 		while (!from->trackers.empty())
 		{

--- a/Client/App/v8world/MotorJoint.cpp
+++ b/Client/App/v8world/MotorJoint.cpp
@@ -36,7 +36,7 @@ namespace RBX
 		}
 		else
 		{
-			RBXAssert(me == getPrimitive(0));
+			RBXASSERT(me == getPrimitive(0));
 			return p1InP0.inverse();
 		}
 	}
@@ -65,10 +65,10 @@ namespace RBX
 
 	void MotorJoint::setJointAngle(float value)
 	{
-		RBXAssert(link);
+		RBXASSERT(link);
 		if (polarity == -1)
 		{
-			RBXAssert(0);
+			RBXASSERT(0);
 			G3D::CoordinateFrame oldParentCoord = getPrimitive(0)->getCoordinateFrame();
 			link->setJointAngle(-value);
 			Assembly* assembly = getPrimitive(1)->getAssembly();

--- a/Client/App/v8world/MutilJoint.cpp
+++ b/Client/App/v8world/MutilJoint.cpp
@@ -35,8 +35,8 @@ namespace RBX
 
 	MultiJoint::~MultiJoint()
 	{
-		RBXAssert(connector[0] == NULL);
-		RBXAssert(numConnector == 0);
+		RBXASSERT(connector[0] == NULL);
+		RBXASSERT(numConnector == 0);
 	}
 
 	void MultiJoint::putInKernel(Kernel* _kernel)
@@ -46,7 +46,7 @@ namespace RBX
 
 	void MultiJoint::addToMultiJoint(Point* point0, Point* point1, Connector* _connector)
 	{
-		RBXAssert(numConnector < 4);
+		RBXASSERT(numConnector < 4);
 
 		point[(numConnector*2)] = point0;
 		point[(numConnector*2)+1] = point1;
@@ -58,26 +58,26 @@ namespace RBX
 
 	Point* MultiJoint::getPoint(int id)
 	{
-		RBXAssert(id < 8);
-		RBXAssert(point[id]);
+		RBXASSERT(id < 8);
+		RBXASSERT(point[id]);
 		return point[id];
 	}
 
 	void MultiJoint::removeFromKernel()
 	{
-		RBXAssert(this->inKernel());
+		RBXASSERT(this->inKernel());
 
 		for (int i = 0; i < numConnector; i++)
 		{
-			RBXAssert(point[(i*2)]);
-			RBXAssert(point[(i*2)+1]);
+			RBXASSERT(point[(i*2)]);
+			RBXASSERT(point[(i*2)+1]);
 
 			getKernel()->deletePoint(point[(i*2)]);
 			getKernel()->deletePoint(point[(i*2)+1]);
 			point[(i*2)] = NULL;
 			point[(i*2)+1] = NULL;
 
-			RBXAssert(connector[i]);
+			RBXASSERT(connector[i]);
 
 			getKernel()->removeConnector(connector[i]);
 			delete connector[i];
@@ -87,17 +87,17 @@ namespace RBX
 		numConnector = 0;
 
 		IPipelined::removeFromKernel();
-		RBXAssert(!this->inKernel());
+		RBXASSERT(!this->inKernel());
 	}
 
 	bool MultiJoint::isBroken() const
 	{
-		RBXAssert(numBreakingConnectors <= numConnector);
-		RBXAssert(this->inKernel());
+		RBXASSERT(numBreakingConnectors <= numConnector);
+		RBXASSERT(this->inKernel());
 
 		for (int i = 0; i < numBreakingConnectors; i++)
 		{
-			RBXAssert(connector[i]);
+			RBXASSERT(connector[i]);
 			if (connector[i]->getBroken())
 				return true;
 		}

--- a/Client/App/v8world/RotateJoint.cpp
+++ b/Client/App/v8world/RotateJoint.cpp
@@ -23,23 +23,23 @@ namespace RBX
 
 	RotateJoint::~RotateJoint()
 	{
-		RBXAssert(!rotateConnector);
+		RBXASSERT(!rotateConnector);
 	}
 
 	void RotateJoint::removeFromKernel()
 	{
-		RBXAssert(getKernel());
+		RBXASSERT(getKernel());
 		rotateConnector = NULL;
 		MultiJoint::removeFromKernel();
 	}
 
 	float RotateJoint::getChannelValue(int uiStepId)
 	{
-		RBXAssert(getAxlePrim());
+		RBXASSERT(getAxlePrim());
 		const SurfaceData& axleSurface = getAxlePrim()->getSurfaceData(getAxleId());
 
 		Controller* controller = getAxlePrim()->getController();
-		RBXAssert(controller);
+		RBXASSERT(controller);
 
 		float value = controller->getValue(axleSurface.inputType);
 		float paramA = axleSurface.paramA;
@@ -92,7 +92,7 @@ namespace RBX
 		case ROTATE_V:
 			return new RotateVJoint(axlePrim, holePrim, c0, c1);
 		default:
-			RBXAssert(0);
+			RBXASSERT(0);
 			return NULL;
 		}
 	}
@@ -221,7 +221,7 @@ namespace RBX
 			Point* pMarker0 = getKernel()->newPoint(b0, marker0);
 			Point* pMarker1 = getKernel()->newPoint(b1, marker0);
 
-			RBXAssert(!rotateConnector);
+			RBXASSERT(!rotateConnector);
 			RotateConnector* connector = new RotateConnector(getPoint(0), getPoint(2), pMarker0, pMarker1, getJointK(), getTorqueArmLength());
 			rotateConnector = connector;
 			addToMultiJoint(pMarker0, pMarker1, connector);

--- a/Client/App/v8world/SeparateStage.cpp
+++ b/Client/App/v8world/SeparateStage.cpp
@@ -17,7 +17,7 @@ namespace RBX
 
 	SeparateStage::~SeparateStage()
 	{
-		RBXAssert(inContact.empty());
+		RBXASSERT(inContact.empty());
 	}
 
 	SleepStage* SeparateStage::getSleepStage()
@@ -64,7 +64,7 @@ namespace RBX
 
 	void SeparateStage::onEdgeAdded(Edge* e)
 	{
-		RBXAssert(!e->inOrDownstreamOfStage(this));
+		RBXASSERT(!e->inOrDownstreamOfStage(this));
 
 		e->putInStage(this);
 		if (e->getEdgeType() == Edge::CONTACT)
@@ -72,7 +72,7 @@ namespace RBX
 			Contact* c = rbx_static_cast<Contact*>(e);
 
 			bool inserted = inContact.insert(c).second;
-			RBXAssert(inserted);
+			RBXASSERT(inserted);
 		}
 
 		getDownstreamWS()->onEdgeAdded(e);
@@ -87,7 +87,7 @@ namespace RBX
 			Contact* c = rbx_static_cast<Contact*>(e);
 
 			size_t removed = inContact.erase(c);
-			RBXAssert(removed == 1);
+			RBXASSERT(removed == 1);
 		}
 
 		e->removeFromStage(this);

--- a/Client/App/v8world/SimJobStage.cpp
+++ b/Client/App/v8world/SimJobStage.cpp
@@ -12,14 +12,14 @@ namespace RBX
 	{
 		Assembly* a0 = e->getPrimitive(0)->getAssembly();
 		Assembly* a1 = e->getPrimitive(1)->getAssembly();
-		RBXAssert(a0 && a1);
+		RBXASSERT(a0 && a1);
 
 		return true;
 	}
 
 	Mechanism* SimJobStage::nextMechanism(std::list<Mechanism*>& list, const Mechanism* current)
 	{
-		RBXAssert(!list.empty());
+		RBXASSERT(!list.empty());
 		std::list<Mechanism*>::iterator myIt = current->myIt;
 		myIt++;
 		if (myIt == list.end())
@@ -34,7 +34,7 @@ namespace RBX
 
 	void SimJobStage::onEdgeRemoving(Edge* e)
 	{
-		RBXAssert(validateEdge(e));
+		RBXASSERT(validateEdge(e));
 
 		e->removeFromKernel();
 		e->removeFromStage(this);
@@ -55,7 +55,7 @@ namespace RBX
 		this->mechanisms.push_back(m);
 		std::list<Mechanism*>::iterator mechEnd = this->mechanisms.end();
 		mechEnd--;
-		RBXAssert(*mechEnd == m);
+		RBXASSERT(*mechEnd == m);
 		m->myIt = mechEnd;
 	}
 
@@ -71,7 +71,7 @@ namespace RBX
 
 	void SimJobStage::destroyMechanism(Mechanism* m)
 	{
-		RBXAssert(std::find(this->mechanisms.begin(), this->mechanisms.end(), m) == m->myIt);
+		RBXASSERT(std::find(this->mechanisms.begin(), this->mechanisms.end(), m) == m->myIt);
 		Mechanism* next = this->mechanisms.size() > 1 ? this->nextMechanism(this->mechanisms, m) : NULL;
 		MechanismTracker::transferTrackers(m, next);
 		this->mechanisms.erase(m->myIt);
@@ -81,7 +81,7 @@ namespace RBX
 	void SimJobStage::onAssemblyAdded(Assembly* a)
 	{
 		a->putInStage(this);
-		RBXAssert(!a->getMechanism());
+		RBXASSERT(!a->getMechanism());
 		Mechanism* newMech = new Mechanism;
 		newMech->insertAssembly(a);
 		this->insertMechanism(newMech);
@@ -100,15 +100,15 @@ namespace RBX
 
 	void SimJobStage::combineMechanisms(Edge* e)
 	{
-		RBXAssert(e->getEdgeType() == Edge::JOINT);
-		RBXAssert(!RigidJoint::isRigidJoint(e));
-		RBXAssert(!MotorJoint::isMotorJoint(e));
+		RBXASSERT(e->getEdgeType() == Edge::JOINT);
+		RBXASSERT(!RigidJoint::isRigidJoint(e));
+		RBXASSERT(!MotorJoint::isMotorJoint(e));
 
 		Joint* j = rbx_static_cast<Joint*>(e);
 		Assembly* a0 = e->getPrimitive(0)->getAssembly();
 		Assembly* a1 = e->getPrimitive(1)->getAssembly();
-		RBXAssert(a0->inOrDownstreamOfStage(this));
-		RBXAssert(a1->inOrDownstreamOfStage(this));
+		RBXASSERT(a0->inOrDownstreamOfStage(this));
+		RBXASSERT(a1->inOrDownstreamOfStage(this));
 
 		Mechanism* m0 = a0->getMechanism();
 		Mechanism* m1 = a1->getMechanism();
@@ -129,7 +129,7 @@ namespace RBX
 
 	void SimJobStage::onEdgeAdded(Edge* e)
 	{
-		RBXAssert(validateEdge(e));
+		RBXASSERT(validateEdge(e));
 
 		e->putInStage(this);
 
@@ -140,8 +140,8 @@ namespace RBX
 
 			if (a0->inOrDownstreamOfStage(this) && a1->inOrDownstreamOfStage(this))
 			{
-				RBXAssert(a0->getDof() > 0);
-				RBXAssert(a1->getDof() > 0);
+				RBXASSERT(a0->getDof() > 0);
+				RBXASSERT(a1->getDof() > 0);
 
 				combineMechanisms(e);
 			}

--- a/Client/App/v8world/SleepStage.cpp
+++ b/Client/App/v8world/SleepStage.cpp
@@ -18,9 +18,9 @@ namespace RBX
 
 	SleepStage::~SleepStage()
 	{
-		RBXAssert(awake.empty());
-		RBXAssert(sleepingChecking.empty());
-		RBXAssert(sleepingDeeply.empty());
+		RBXASSERT(awake.empty());
+		RBXASSERT(sleepingChecking.empty());
+		RBXASSERT(sleepingDeeply.empty());
 	}
 
 	int SleepStage::stepsToSleep()
@@ -53,7 +53,7 @@ namespace RBX
 				checkSleepingAssemblies();
 		}
 
-		RBXAssert(getDownstream());
+		RBXASSERT(getDownstream());
 		getDownstream()->stepWorld(worldStepId, uiStepId, throttling);
 	}
 
@@ -61,15 +61,15 @@ namespace RBX
 	{
 		if (assembly->getSleepStatus() == Sim::AWAKE)
 		{
-			RBXAssert(assembly->downstreamOfStage(this));
+			RBXASSERT(assembly->downstreamOfStage(this));
 			rbx_static_cast<SeparateStage*>(getDownstreamWS())->onAssemblyRemoving(assembly);
 		}
 
-		RBXAssert(assembly->inStage(this));
+		RBXASSERT(assembly->inStage(this));
 
 		std::set<Assembly*>& assemblyArray = statusToArray(assembly->getSleepStatus());
 		size_t removed = assemblyArray.erase(assembly);
-		RBXAssert(removed == 1);
+		RBXASSERT(removed == 1);
 
 		assembly->setSleepStatus(Sim::AWAKE);
 		assembly->setSleepCount(0);
@@ -77,13 +77,13 @@ namespace RBX
 
 	void SleepStage::insert(Assembly* assembly, Sim::AssemblyState newStatus)
 	{
-		RBXAssert(assembly->getSleepCount() == 0);
-		RBXAssert(assembly->getSleepStatus() == Sim::AWAKE);
-		RBXAssert(!assembly->downstreamOfStage(this));
+		RBXASSERT(assembly->getSleepCount() == 0);
+		RBXASSERT(assembly->getSleepStatus() == Sim::AWAKE);
+		RBXASSERT(!assembly->downstreamOfStage(this));
 
 		std::set<Assembly*>& assemblyArray = statusToArray(newStatus);
 		bool inserted = assemblyArray.insert(assembly).second;
-		RBXAssert(inserted);
+		RBXASSERT(inserted);
 
 		assembly->setSleepStatus(newStatus);
 		if (assembly->getSleepStatus() == Sim::AWAKE)
@@ -100,8 +100,8 @@ namespace RBX
 
 	void SleepStage::onAssemblyAdded(Assembly* assembly)
 	{
-		RBXAssert(!assembly->getAnchored());
-		RBXAssert(assembly->getSleepStatus() == Sim::AWAKE);
+		RBXASSERT(!assembly->getAnchored());
+		RBXASSERT(assembly->getSleepStatus() == Sim::AWAKE);
 
 		assembly->putInStage(this);
 		insert(assembly, Sim::AWAKE);
@@ -109,22 +109,22 @@ namespace RBX
 
 	void SleepStage::onAssemblyRemoving(Assembly* assembly)
 	{
-		RBXAssert(assembly->inOrDownstreamOfStage(this));
+		RBXASSERT(assembly->inOrDownstreamOfStage(this));
 
 		remove(assembly);
-		RBXAssert(assembly->getSleepStatus() == Sim::AWAKE);
+		RBXASSERT(assembly->getSleepStatus() == Sim::AWAKE);
 		assembly->removeFromStage(this);
 	}
 
 	void SleepStage::onEdgeAdded(Edge* e)
 	{
-		RBXAssert(!e->inOrDownstreamOfStage(this));
+		RBXASSERT(!e->inOrDownstreamOfStage(this));
 
 		Assembly* a0 = e->getPrimitive(0)->getAssembly();
 		Assembly* a1 = e->getPrimitive(1)->getAssembly();
 
-		RBXAssert(!a0->getAnchored() || !a1->getAnchored());
-		RBXAssert(a0->inOrDownstreamOfStage(this) || a1->inOrDownstreamOfStage(this));
+		RBXASSERT(!a0->getAnchored() || !a1->getAnchored());
+		RBXASSERT(a0->inOrDownstreamOfStage(this) || a1->inOrDownstreamOfStage(this));
 
 		bool a0Awoken = false;
 		bool a1Awoken = false;
@@ -152,14 +152,14 @@ namespace RBX
 
 	void SleepStage::onEdgeRemoving(Edge* e)
 	{
-		RBXAssert(e->inOrDownstreamOfStage(this));
+		RBXASSERT(e->inOrDownstreamOfStage(this));
 
 		if (e->downstreamOfStage(this))
 			getDownstreamWS()->onEdgeRemoving(e);
 
 		Assembly* a0 = e->getPrimitive(0)->getAssembly();
 		Assembly* a1 = e->getPrimitive(1)->getAssembly();
-		RBXAssert(a0->inOrDownstreamOfStage(this) || a1->inOrDownstreamOfStage(this));
+		RBXASSERT(a0->inOrDownstreamOfStage(this) || a1->inOrDownstreamOfStage(this));
 
 		e->removeFromStage(this);
 
@@ -171,7 +171,7 @@ namespace RBX
 
 	bool SleepStage::shouldSleep(Assembly* assembly)
 	{
-		RBXAssert(assembly->getSleepStatus() == Sim::AWAKE);
+		RBXASSERT(assembly->getSleepStatus() == Sim::AWAKE);
 		if (!assembly->getCanSleep())
 			return false;
 		if (!assembly->calcShouldSleep())
@@ -195,7 +195,7 @@ namespace RBX
 
 	Sim::AssemblyState SleepStage::shouldWakeOrSleepDeeply(Assembly* assembly)
 	{
-		RBXAssert(assembly->getSleepStatus() == Sim::SLEEPING_CHECKING);
+		RBXASSERT(assembly->getSleepStatus() == Sim::SLEEPING_CHECKING);
 		if (!assembly->getCanSleep())
 			return Sim::AWAKE;
 
@@ -221,7 +221,7 @@ namespace RBX
 
 	void SleepStage::goToSleep(Assembly* assembly)
 	{
-		RBXAssert(assembly->getSleepStatus() == Sim::AWAKE);
+		RBXASSERT(assembly->getSleepStatus() == Sim::AWAKE);
 
 		typedef std::set<Edge*>::iterator Iterator;
 		for (Iterator it = assembly->getExternalEdges().begin(); it != assembly->getExternalEdges().end(); it++)
@@ -244,9 +244,9 @@ namespace RBX
 
 	void SleepStage::wakeAssembly(Assembly* assembly)
 	{
-		RBXAssert(assembly->getSleepStatus() != Sim::AWAKE);
-		RBXAssert(!assembly->getAnchored());
-		RBXAssert(assembly->inOrDownstreamOfStage(this));
+		RBXASSERT(assembly->getSleepStatus() != Sim::AWAKE);
+		RBXASSERT(!assembly->getAnchored());
+		RBXASSERT(assembly->inOrDownstreamOfStage(this));
 
 		changeSleepStatus(assembly, Sim::AWAKE);
 	}
@@ -300,7 +300,7 @@ namespace RBX
 			Assembly* a0 = c->getPrimitive(0)->getAssembly();
 			Assembly* a1 = c->getPrimitive(1)->getAssembly();
 
-			RBXAssert(a0->inOrDownstreamOfStage(this) || a1->inOrDownstreamOfStage(this));
+			RBXASSERT(a0->inOrDownstreamOfStage(this) || a1->inOrDownstreamOfStage(this));
 
 			if (a0->getSleepStatus() != Sim::AWAKE)
 				wakeAssemblyAndNeighbors(a0, 8);
@@ -312,13 +312,13 @@ namespace RBX
 		{
 			Contact* c = separating[i];
 
-			RBXAssert(c->inOrDownstreamOfStage(this));
+			RBXASSERT(c->inOrDownstreamOfStage(this));
 			if (c->downstreamOfStage(this))
 			{
 				getDownstreamWS()->onEdgeRemoving(c);
 			}
 
-			RBXAssert(c->inStage(this));
+			RBXASSERT(c->inStage(this));
 			c->removeFromStage(this);
 		}
 
@@ -339,7 +339,7 @@ namespace RBX
 		for (Iterator it = awake.begin(); it != awake.end(); it++)
 		{
 			Assembly* assembly = *it;
-			RBXAssert(!assembly->getAnchored());
+			RBXASSERT(!assembly->getAnchored());
 
 			if (!throttling || !assembly->getMainPrimitive()->getBody()->getCanThrottle())
 			{
@@ -374,8 +374,8 @@ namespace RBX
 		for (Iterator it = sleepingChecking.begin(); it != sleepingChecking.end(); it++)
 		{
 			Assembly* assembly = *it;
-			RBXAssert(!assembly->getAnchored());
-			RBXAssert(assembly->getSleepCount() == 0);
+			RBXASSERT(!assembly->getAnchored());
+			RBXASSERT(assembly->getSleepCount() == 0);
 
 			Sim::AssemblyState state = shouldWakeOrSleepDeeply(assembly);
 


### PR DESCRIPTION
The title explains it. Used the find/replace function to replace all instances of RBXAssert with RBXASSERT.

Due to this being a mostly automated change, I suggest that this PR be looked through before implementing.

~Just in case if this PR gets added while new code gets written, a new definition was created that replicates the behavior of the original RBXAssert. This is meant to be temporary, so remove it when RBXASSERT is fully used in the codebase:~

~`#define RBXAssert(expr) RBXASSERT(expr)`~

EDIT: The RBXAssert definition was removed on request.