### PR TITLE
Block::getMomentHollow, 76% match

### DIFF
--- a/Client/App/v8world/Block.cpp
+++ b/Client/App/v8world/Block.cpp
@@ -115,7 +115,7 @@ namespace RBX
 
 			float scaling = mass / (2 * area);
 
-			float temp = ((Z*Z*Z*Y)/3) + ((Z*Y*Y*Y)/3) + ((Y*Y*Y*X)/3) + ((Z*Z*Y*X)) + ((Z*X*Y*Y)) + ((X*Z*Z*Z)/3);
+			float temp = ((Z*Z*Z*Y)/3) + ((Z*Y*Y*Y)/3) + ((Y*Y*Y*X)/3) + (Z*Z*Y*X) + (Z*X*Y*Y) + ((X*Z*Z*Z)/3);
 
 			I[i] = temp * scaling;
 		}


### PR DESCRIPTION
Math expressions are a pain to match. Still got it somewhat though.