### PR TITLE
fix most linker errors

### DIFF
--- a/Client/App/include/v8kernel/Link.h
+++ b/Client/App/include/v8kernel/Link.h
@@ -12,14 +12,14 @@ namespace RBX
 			G3D::CoordinateFrame parentCoord;
 			G3D::CoordinateFrame childCoord;
 			G3D::CoordinateFrame childCoordInverse;
-			G3D::CoordinateFrame childInParent;
+			mutable G3D::CoordinateFrame childInParent;
 			mutable int stateIndex;
-			virtual void computeChildInParent(const G3D::CoordinateFrame& answer) const;
+			virtual void computeChildInParent(G3D::CoordinateFrame& answer) const = 0;
 			void dirty();
 			//void setBody(RBX::Body* _body){ body = _body;}
 		public:
 			Link();
-			~Link();
+			//~Link();
 			const G3D::CoordinateFrame& getChildInParent() const;
 			Body* getBody() const;
 			void reset(const G3D::CoordinateFrame&, const G3D::CoordinateFrame&);

--- a/Client/App/include/v8world/Contact.h
+++ b/Client/App/include/v8world/Contact.h
@@ -33,8 +33,8 @@ namespace RBX
 		ContactConnector* createConnector();
 		void deleteConnector(ContactConnector*& c);
 		void deleteConnectorInline(ContactConnector*& c); //for matching only
-		virtual void deleteAllConnectors();
-		virtual bool stepContact();
+		virtual void deleteAllConnectors() = 0;
+		virtual bool stepContact() = 0;
 	public:
 		Contact(Primitive* prim0, Primitive* prim1);
 		virtual ~Contact() {}
@@ -43,7 +43,7 @@ namespace RBX
 		{
 			return steppingIndex;
 		}
-		virtual bool computeIsColliding(float);
+		virtual bool computeIsColliding(float) = 0;
 		bool computeIsAdjacent(float spaceAllowed);
 		void onPrimitiveContactParametersChanged();
 		bool step(int uiStepId);

--- a/Client/App/include/v8world/Controller.h
+++ b/Client/App/include/v8world/Controller.h
@@ -72,7 +72,7 @@ namespace RBX
 		//NullController(const NullController&);
 		NullController() : Controller() {}
 
-		virtual ~NullController();
+		//virtual ~NullController();
 
 		//NullController& operator=(const NullController&);
 

--- a/Client/App/include/v8world/Edge.h
+++ b/Client/App/include/v8world/Edge.h
@@ -41,7 +41,7 @@ namespace RBX
 
 		bool getInEdgeList() const;
 		void setInEdgeList(bool);
-		virtual EdgeType getEdgeType() const;
+		virtual EdgeType getEdgeType() const = 0;
 		Sim::EdgeState getEdgeState() const;
 		void setEdgeState(Sim::EdgeState);
 		Primitive* getPrimitive(int i) const

--- a/Client/App/include/v8world/JointStage.h
+++ b/Client/App/include/v8world/JointStage.h
@@ -36,7 +36,10 @@ namespace RBX
 		JointStage(IStage* upstream, World* world);
 		virtual ~JointStage();
 	public:
-		virtual IStage::StageType getStageType();
+		virtual IStage::StageType getStageType()
+		{
+			return JOINT_STAGE;
+		}
 		virtual void onEdgeAdded(Edge* e);
 		virtual void onEdgeRemoving(Edge* e);
 		void onPrimitiveAdded(Primitive* p);

--- a/Client/App/v8world/Block.cpp
+++ b/Client/App/v8world/Block.cpp
@@ -71,6 +71,8 @@ namespace RBX
 		}
 	};
 
+	BlockTemplate::BlockTemplates BlockTemplate::blockTemplates; // TODO: check if correct
+
 	const int Block::BLOCK_FACE_TO_VERTEX[6][4] = {
 		{0, 2, 3, 1},
 		{0, 1, 5, 4},
@@ -80,7 +82,7 @@ namespace RBX
 		{1, 3, 7, 5}
 	};
 
-	const int BLOCK_FACE_VERTEX_TO_EDGE[6][4] = {
+	const int Block::BLOCK_FACE_VERTEX_TO_EDGE[6][4] = {
 		{4, 11, 5, 8},
 		{8, 3, 9, 0},
 		{0, 7, 1, 4},

--- a/Client/App/v8world/Contact.cpp
+++ b/Client/App/v8world/Contact.cpp
@@ -5,6 +5,9 @@
 
 namespace RBX
 {
+	int Contact::contactPairMatches = 0;
+	int Contact::contactPairMisses = 0;
+
 	__declspec(noinline) Contact::Contact(Primitive* prim0, Primitive* prim1)
 		: Edge(prim0, prim1),
 		jointK(0),

--- a/Client/App/v8world/ContactManager.cpp
+++ b/Client/App/v8world/ContactManager.cpp
@@ -4,6 +4,8 @@
 
 namespace RBX
 {
+	bool ContactManager::ignoreBool = false;
+
 	ContactManager::ContactManager(World* world)
 	{
 		SpatialHash* hash = new SpatialHash(world, this);

--- a/Client/App/v8world/Primitive.cpp
+++ b/Client/App/v8world/Primitive.cpp
@@ -8,6 +8,9 @@
 
 namespace RBX 
 {
+	bool Primitive::ignoreBool = false;
+	bool Primitive::disableSleep = false;
+
 	#pragma warning (push)
 	#pragma warning (disable : 4355) // warning C4355: 'this' : used in base member initializer list
 	Primitive::Primitive(Geometry::GeometryType geometryType) :
@@ -569,5 +572,26 @@ namespace RBX
 		e->setNext(p, list.first);
 		list.first = e;
 		list.num++;
+	}
+
+	void EdgeList::removeEdge(Primitive* p, Edge* e, EdgeList& list)
+	{
+		if(list.first == e)
+		{
+			list.first = list.first->getNext(p);
+		}
+		else
+		{
+			Edge* currentEdge = list.first;
+
+			while(currentEdge->getNext(p) != e)
+			{
+				currentEdge = currentEdge->getNext(p);
+			}
+
+			currentEdge->setNext(p, e->getNext(p));
+		}
+
+		list.num--;
 	}
 }

--- a/Client/App/v8world/World.cpp
+++ b/Client/App/v8world/World.cpp
@@ -14,6 +14,8 @@
 
 namespace RBX
 {
+	bool World::disableEnvironmentalThrottle = false;
+
 	#pragma warning (push)
 	#pragma warning (disable : 4355) // warning C4355: 'this' : used in base member initializer list
 	World::World() : 


### PR DESCRIPTION
+ EdgeList::removeEdge 90% match

After this commit, the only linker errors should come from the Notifier class, which has been (somewhat) implemented in PR #68