### PR TITLE
FIX: avoid creating new objects, reference pre-existing static objects

### DIFF
--- a/Client/App/util/Math.cpp
+++ b/Client/App/util/Math.cpp
@@ -203,8 +203,8 @@ namespace RBX
 
 	const G3D::Matrix3& Math::getAxisRotationMatrix(int face)
 	{
-		static G3D::Matrix3 y = G3D::Matrix3::fromEulerAnglesXYZ(0, 0, G3D::halfPi());
-		static G3D::Matrix3 z = G3D::Matrix3::fromEulerAnglesXYZ(0, G3D::halfPi(), 0);
+		static G3D::Matrix3 y = G3D::Matrix3::fromEulerAnglesXYZ(0.0f, 0.0f, (float)G3D::halfPi());
+		static G3D::Matrix3 z = G3D::Matrix3::fromEulerAnglesXYZ(0.0f, (float)G3D::halfPi(), 0.0f);
 		static G3D::Matrix3 y_neg = G3D::Matrix3(y);
 		static G3D::Matrix3 z_neg = G3D::Matrix3(z);
 

--- a/Client/Rendering/AppDraw/Draw.cpp
+++ b/Client/Rendering/AppDraw/Draw.cpp
@@ -84,7 +84,7 @@ namespace RBX
 
         G3D::Vector3 halfSize = part.gridSize * 0.5f;
 
-        G3D::Matrix3 rot = Math::getAxisRotationMatrix(face);
+       const G3D::Matrix3& relativeRotation = Math::getAxisRotationMatrix(face);
 
         G3D::Vector3 relativeTranslation;
 
@@ -93,7 +93,7 @@ namespace RBX
 
         relativeTranslation[axis] = halfSize[axis]*posNeg;
 
-        G3D::CoordinateFrame translation(rot, relativeTranslation);
+        G3D::CoordinateFrame translation(relativeRotation, relativeTranslation);
         G3D::CoordinateFrame newObject = part.coordinateFrame*translation;
 
         adorn->setObjectToWorldMatrix(newObject);


### PR DESCRIPTION
Using a `const` reference will tell the compiler to not create a nw stack slot for this, just use the memory returned by the function.

The rest of this code should be 100% match.