### PR TITLE
physics match improvements, code cleanup

### DIFF
--- a/Client/App/include/util/Events.h
+++ b/Client/App/include/util/Events.h
@@ -67,7 +67,7 @@ namespace RBX
 
 			raiseRange = &range;
 
-			for(; range.index < range.upper; range.index++)
+			for (; range.index < range.upper; range.index++)
 			{
 				raise(event, listeners[range.index]);
 			}

--- a/Client/App/include/v8world/ClumpStage.h
+++ b/Client/App/include/v8world/ClumpStage.h
@@ -22,10 +22,10 @@ namespace RBX
 	{
 	public:
 		bool anchored;
-		int surfaceAreaJoints;
+		size_t surfaceAreaJoints;
 	  
 	public:
-		//PrimitiveSort(const PrimitiveSort&);
+		PrimitiveSort(const PrimitiveSort& other);
 		PrimitiveSort(const Primitive* p);
 		PrimitiveSort();
 	public:

--- a/Client/App/include/v8world/Edge.h
+++ b/Client/App/include/v8world/Edge.h
@@ -60,7 +60,7 @@ namespace RBX
 		}
 		void setNext(Primitive* p, Edge* e)
 		{
-			if(p == prim0)
+			if (p == prim0)
 				next0 = e;
 			else
 				next1 = e;

--- a/Client/App/util/Math.cpp
+++ b/Client/App/util/Math.cpp
@@ -602,16 +602,16 @@ namespace RBX
 		int maxI = -1, maxJ = -1;
 		float maxDot = 0.0f;
 
-		for(int i = 0; i < 3; i++)
+		for (int i = 0; i < 3; i++)
 		{
 			G3D::Vector3 aAxis = align.getColumn(i);
-			for(int j = 0; j < 3; j++)
+			for (int j = 0; j < 3; j++)
 			{
 				G3D::Vector3 tAxis = target.getColumn(j);
 				float atDot = aAxis.dot(tAxis);
 				dots[i][j] = atDot;
 
-				if(fabs(atDot) > fabs(maxDot))
+				if (fabs(atDot) > fabs(maxDot))
 				{
 					maxI = i;
 					maxJ = j;
@@ -626,12 +626,12 @@ namespace RBX
 		float maxDot1 = 0.0f;
 		int maxI1 = -1, maxJ1 = -1;
 
-		for(int i = 0; i < 3; i++)
+		for (int i = 0; i < 3; i++)
 		{
-			if(i != maxI)
-				for(int j = 0; j < 3; j++)
+			if (i != maxI)
+				for (int j = 0; j < 3; j++)
 				{
-					if(j != maxJ && fabs(dots[i][j]) > fabs(maxDot1))
+					if (j != maxJ && fabs(dots[i][j]) > fabs(maxDot1))
 					{
 						maxDot1 = dots[i][j];
 						maxI1 = i;

--- a/Client/App/util/NormalId.cpp
+++ b/Client/App/util/NormalId.cpp
@@ -86,7 +86,7 @@ namespace RBX
 
 	NormalId inlinedFunction1(NormalId id)
 	{
-		switch(id)
+		switch (id)
 		{
 		case NORM_X:
 			return NORM_Z_NEG;
@@ -108,7 +108,7 @@ namespace RBX
 
 	NormalId inlinedFunction2(NormalId id)
 	{
-		switch(id)
+		switch (id)
 		{
 		case NORM_X:
 			return NORM_Z;
@@ -130,7 +130,7 @@ namespace RBX
 
 	const G3D::Matrix3& normalIdToMatrix3(NormalId normalId)
 	{
-		switch(normalId)
+		switch (normalId)
 		{
 		case NORM_X:
 			{
@@ -199,7 +199,7 @@ namespace RBX
 
 	G3D::Vector3 uvwToObject(const G3D::Vector3& uvwPt, NormalId faceId)
 	{
-		switch(faceId)
+		switch (faceId)
 		{
 		case NORM_X:
 			return G3D::Vector3(uvwPt.z, uvwPt.y, -uvwPt.x);
@@ -220,7 +220,7 @@ namespace RBX
 
 	G3D::Vector3 objectToUvw(const G3D::Vector3& objectPt, NormalId faceId)
 	{
-		switch(faceId)
+		switch (faceId)
 		{
 		case NORM_X:
 			return G3D::Vector3(-objectPt.z, objectPt.y, objectPt.x);

--- a/Client/App/v8datamodel/Camera.cpp
+++ b/Client/App/v8datamodel/Camera.cpp
@@ -156,7 +156,7 @@ namespace RBX
 	//87.80% matching.
 	void Camera::updateGoal()
 	{
-		switch(cameraType)
+		switch (cameraType)
 		{
 			case WATCH_CAMERA:
 			{
@@ -204,7 +204,7 @@ namespace RBX
 			case CUSTOM_CAMERA:
 			{
 				ICameraSubject* cameraSubject = getCameraSubject();
-				if(cameraSubject)
+				if (cameraSubject)
 					cameraSubject->stepGoalAndFocus(cameraGoal, cameraFocus, cameraExternallyAdjusted);
 				cameraExternallyAdjusted = false;
 				break;

--- a/Client/App/v8kernel/Constants.cpp
+++ b/Client/App/v8kernel/Constants.cpp
@@ -72,7 +72,7 @@ const float Constants::getJointKMultiplier(const G3D::Vector3& clippedSortedSize
 	{
 		RBXASSERT(size.x >= 1);
 
-		switch(size.x)
+		switch (size.x)
 		{
 		case 1:
 			return 0.23f;

--- a/Client/App/v8tree/Instance.cpp
+++ b/Client/App/v8tree/Instance.cpp
@@ -55,7 +55,7 @@ namespace RBX
 	{
 		const Instance* p = descendent;
 
-		while(p != NULL)
+		while (p != NULL)
 		{
 			p = p->parent;
 			if (p == this)
@@ -255,7 +255,7 @@ namespace RBX
 
 	void Instance::readChildren(const XmlElement* element, IReferenceBinder& binder)
 	{
-		if(element)
+		if (element)
 		{
 			for (const XmlElement* current = element->findFirstChildByTag(tag_Item); current != NULL; current = element->findNextChildWithSameTag(current))
 			{

--- a/Client/App/v8world/Block.cpp
+++ b/Client/App/v8world/Block.cpp
@@ -114,7 +114,7 @@ namespace RBX
 
 		float area = ((grid.x * grid.z + grid.y * grid.z) + grid.x * grid.y) * 2;
 
-		for(int i = 0; i < 3; i++)
+		for (int i = 0; i < 3; i++)
 		{
 			float X = grid[(i    ) % 3];
 			float Y = grid[(i + 1) % 3];

--- a/Client/App/v8world/Clump.cpp
+++ b/Client/App/v8world/Clump.cpp
@@ -255,6 +255,8 @@ namespace RBX
 
 	void Clump::addPrimitive(Primitive* p, Primitive* parent, RigidJoint* j)
 	{
+		MaxRadius.setDirty();
+
 		RBXASSERT(!p->getAnchorObject());
 		RBXASSERT(!p->getClump());
 		RBXASSERT(p->getClumpDepth() == -1);
@@ -269,16 +271,16 @@ namespace RBX
 	void Clump::onPrimitiveCanSleepChanged(Primitive* p)
 	{
 		RBXASSERT(containsPrimitive(p));
-		bool primCanSleep = p->getCanSleep();
-		if (primCanSleep)
+
+		if (p->getCanSleep() && !canSleep)
 		{
-			if (!canSleep)
-				canSleep = computeCanSleep();
+			canSleep = computeCanSleep();
+			return;
 		}
-		else
+
+		if (!p->getCanSleep() && canSleep)
 		{
-			if (canSleep)
-				canSleep = false;
+			canSleep = false;
 		}
 	}
 
@@ -310,7 +312,7 @@ namespace RBX
 
 	bool Clump::computeCanSleep()
 	{
-		typedef std::set<Primitive*>::const_iterator Iterator;
+		typedef std::set<Primitive*>::iterator Iterator;
 
 		for (Iterator iter = primitives.begin(); iter != primitives.end(); iter++)
 		{
@@ -371,7 +373,7 @@ namespace RBX
 	{
 		typedef std::set<Primitive*>::const_iterator Iterator;
 
-		if(primitives.size() == 1)
+		if (primitives.size() == 1)
 			return (rootPrimitive->getGeometry()->getGridSize() * 0.5f).magnitude();
 		else
 		{
@@ -381,7 +383,7 @@ namespace RBX
 
 			G3D::Vector3 branchPos = rootPrimitive->getBody()->getBranchCofmPos();
 
-			for(Iterator it = primitives.begin(); it != primitives.end(); it++)
+			for (Iterator it = primitives.begin(); it != primitives.end(); it++)
 			{
 				Primitive* current = *it;
 

--- a/Client/App/v8world/ClumpStage.cpp
+++ b/Client/App/v8world/ClumpStage.cpp
@@ -26,6 +26,12 @@ namespace RBX
 		this->anchored = p->getAnchor();
 	}
 
+	PrimitiveSort::PrimitiveSort(const PrimitiveSort& other)
+		: anchored(other.anchored),
+		  surfaceAreaJoints(other.surfaceAreaJoints)
+	{
+	}
+
 	PrimitiveEntry::PrimitiveEntry(Primitive* primitive, PrimitiveSort power)
 		: primitive(primitive),
 		  power(power)
@@ -322,18 +328,10 @@ namespace RBX
 		}
 		else
 		{
-			// NOTE: if you get this matching, you will also be able to match processMotors
 			Primitive* c1Root = clump1->getRootPrimitive();
 			Primitive* c0Root = clump0->getRootPrimitive();
-			PrimitiveSort s1 = PrimitiveSort(c1Root);
-			PrimitiveSort s0 = PrimitiveSort(c0Root);
-			//PrimitiveSort* selectedSort = &s1;
 
-			//if (s0 > s1)
-			//	selectedSort = &s0;
-
-			//return *selectedSort;
-			return s0 < s1 ? s1 : s0;
+			return G3D::max(PrimitiveSort(c0Root), PrimitiveSort(c1Root));
 		}
 	}
 
@@ -1026,7 +1024,7 @@ namespace RBX
 			RigidJoint* r = *c->getInconsistents().begin();
 
 			Clump* otherClump = c->otherClump(r);
-			RBXASSERT(otherClump == c);
+			RBXASSERT(otherClump != c);
 
 			otherClump->removeInconsistent(r);
 			c->removeInconsistent(r);

--- a/Client/App/v8world/Contact.cpp
+++ b/Client/App/v8world/Contact.cpp
@@ -549,9 +549,9 @@ namespace RBX
 
 		int foundCounter = 0;
 
-		for(int i = 3; i >= 0; i--)
+		for (int i = 3; i >= 0; i--)
 		{
-			if(otherQuad[i].y <= planeRect.y)
+			if (otherQuad[i].y <= planeRect.y)
 			{
 				quadCrossRect[0][i] = true;
 			}
@@ -561,7 +561,7 @@ namespace RBX
 				quadIn[i] = false;
 			}
 
-			if(otherQuad[i].x >= -planeRect.x)
+			if (otherQuad[i].x >= -planeRect.x)
 			{
 				quadCrossRect[1][i] = true;
 			}
@@ -571,7 +571,7 @@ namespace RBX
 				quadIn[i] = false;
 			}
 
-			if(otherQuad[i].y >= -planeRect.y)
+			if (otherQuad[i].y >= -planeRect.y)
 			{
 				quadCrossRect[2][i] = true;
 			}
@@ -581,7 +581,7 @@ namespace RBX
 				quadIn[i] = false;
 			}
 
-			if(otherQuad[i].x <= planeRect.x)
+			if (otherQuad[i].x <= planeRect.x)
 			{
 				quadCrossRect[3][i] = true;
 			}
@@ -592,16 +592,16 @@ namespace RBX
 			}
 		}
 
-		for(int i = 3; i >= 0; i--)
+		for (int i = 3; i >= 0; i--)
 		{
-			if(quadIn[i])
+			if (quadIn[i])
 			{
 				loadGeoPairPointPlane(bOther, bPlane, i, otherPlaneID, planeID);
 				foundCounter++;
 			}
 		}
 
-		if(foundCounter == 4)
+		if (foundCounter == 4)
 			return foundCounter;
 		else
 		{
@@ -614,16 +614,16 @@ namespace RBX
 
 			bool rectIn[4] = {true, true, true, true};
 
-			for(int i = 3; i >= 0; i--)
+			for (int i = 3; i >= 0; i--)
 			{
 				G3D::Vector2& current = otherQuad[i];
 				G3D::Vector2& currentO = otherQuad[(i + 3) % 4];
-				for(int j = 0; j < 4; j++)
+				for (int j = 0; j < 4; j++)
 				{
 					G3D::Vector2 math1 = rect[j] - current;
 					G3D::Vector2 math2 = currentO - current;
 
-					if((math2.x * math1.y) - (math2.y * math1.x) >= 0.0f)
+					if ((math2.x * math1.y) - (math2.y * math1.x) >= 0.0f)
 					{
 						rectCrossQuad[i][j] = true;
 					}
@@ -637,24 +637,24 @@ namespace RBX
 
 			int wasZero = foundCounter == 0;
 
-			for(int i = 0; i < 4; i++)
+			for (int i = 0; i < 4; i++)
 			{
-				if(rectIn[i])
+				if (rectIn[i])
 				{
 					loadGeoPairPointPlane(bPlane, bOther, i, planeID, otherPlaneID);
 					foundCounter++;
 				}
 			}
 
-			if(wasZero && foundCounter == 4)
+			if (wasZero && foundCounter == 4)
 				return foundCounter;
 			else
 			{
-				for(int i = 0; i < 4; i++)
+				for (int i = 0; i < 4; i++)
 				{
-					for(int j = 3; j >= 0; j--)
+					for (int j = 3; j >= 0; j--)
 					{
-						if(quadCrossRect[i][j] != quadCrossRect[i][(j + 3) % 4] && rectCrossQuad[j][i] != rectCrossQuad[j][(i + 1) % 4])
+						if (quadCrossRect[i][j] != quadCrossRect[i][(j + 3) % 4] && rectCrossQuad[j][i] != rectCrossQuad[j][(i + 1) % 4])
 						{
 
 							loadGeoPairEdgeEdgePlane(bOther, bPlane, block(bOther)->faceVertexToEdge(otherPlaneID, (j+3)%4), block(bPlane)->faceVertexToEdge(planeID, i));
@@ -670,7 +670,7 @@ namespace RBX
 
 	bool BlockBlockContact::computeIsColliding(bool& planeContact, float overlapIgnored)
 	{
-		if(Primitive::aaBoxCollide(*getPrimitive(0), *getPrimitive(1)))
+		if (Primitive::aaBoxCollide(*getPrimitive(0), *getPrimitive(1)))
 			return getBestPlaneEdge(planeContact, overlapIgnored);
 		else
 			return false;
@@ -685,13 +685,13 @@ namespace RBX
 	bool BlockBlockContact::stepContact()
 	{
 		bool planeContact;
-		if(computeIsColliding(planeContact, 0.0f))
+		if (computeIsColliding(planeContact, 0.0f))
 		{
-			if(inStage(IStage::KERNEL_STAGE))
+			if (inStage(IStage::KERNEL_STAGE))
 			{
 				matched.resize(0);
 				matched.resize(connectors.size());
-				if(planeContact)
+				if (planeContact)
 				{
 					computePlaneContact();
 					deleteUnmatchedConnectors();
@@ -713,7 +713,7 @@ namespace RBX
 
 	int BlockBlockContact::computePlaneContact()
 	{
-		if(feature[0] >= 0)
+		if (feature[0] >= 0)
 		{
 			planeID = (NormalId)feature[0];
 			bPlane = 0;
@@ -741,7 +741,7 @@ namespace RBX
 
 		G3D::Vector2 otherQuad[4] = {};
 
-		for(int i = 0; i < 4; i++)
+		for (int i = 0; i < 4; i++)
 		{
 			G3D::Vector3 world = otherToPlane.pointToWorldSpace(*(otherBlock->getFaceVertex(otherPlaneID, i)));
 			otherQuad[i] = otherBlock->getProjectedVertex(world, planeID);

--- a/Client/App/v8world/ContactManager.cpp
+++ b/Client/App/v8world/ContactManager.cpp
@@ -66,9 +66,9 @@ namespace RBX
 	{
 		std::set<Primitive*> checkSet(check.begin(), check.end());
 
-		for(int i = 0; i < check.size(); i++)
+		for (int i = 0; i < check.size(); i++)
 		{
-			if(intersectingOthers(check[i], checkSet, overlapIgnored))
+			if (intersectingOthers(check[i], checkSet, overlapIgnored))
 				return true;
 		}
 		return false;
@@ -76,9 +76,9 @@ namespace RBX
 
 	bool ContactManager::intersectingOthers(Primitive* check, const std::set<Primitive*>& checkSet, float overlapIgnored)
 	{
-		for(Contact* cur = check->getFirstContact(); cur != NULL; cur = check->getNextContact(cur))
+		for (Contact* cur = check->getFirstContact(); cur != NULL; cur = check->getNextContact(cur))
 		{
-			if(checkSet.find(cur->otherPrimitive(check)) == checkSet.end() && cur->computeIsColliding(overlapIgnored))
+			if (checkSet.find(cur->otherPrimitive(check)) == checkSet.end() && cur->computeIsColliding(overlapIgnored))
 				return true;
 		}
 		return false;
@@ -88,13 +88,13 @@ namespace RBX
 	{
 		G3D::Array<Contact*> newContacts;
 
-		for(Contact* cur = p->getFirstContact(); cur != NULL; cur = p->getFirstContact())
+		for (Contact* cur = p->getFirstContact(); cur != NULL; cur = p->getFirstContact())
 		{
 			newContacts.push_back(createContact(cur->getPrimitive(0), cur->getPrimitive(1)));
 			world->destroyContact(cur);
 		}
 
-		for(int i = 0; i < newContacts.size(); i++)
+		for (int i = 0; i < newContacts.size(); i++)
 		{
 			world->insertContact(newContacts[i]);
 		}
@@ -116,10 +116,10 @@ namespace RBX
 
 		Primitive* fastHit = getFastHit(worldRay, ignorePrim, filter, hitPoint, inside, stopped);
 
-		if(stopped) 
+		if (stopped) 
 			fastHit = NULL;
 
-		if(!fastHit) 
+		if (!fastHit) 
 		{
 			hitPoint = G3D::Vector3::zero();
 			inside = false;
@@ -146,14 +146,14 @@ namespace RBX
 			spatialHash->getPrimitivesInGrid(grid, primitives);
 			Primitive* slowHit = getSlowHit(primitives, unitRay, ignorePrim, filter, hitPointWorld, magnitude, inside, stopped);
 
-			if(slowHit)
+			if (slowHit)
 			{
 				Extents hashGrid = SpatialHash::hashGridToRealExtents(grid.toVector3());
-				if(hashGrid.fuzzyContains(hitPointWorld, 0.001f))
+				if (hashGrid.fuzzyContains(hitPointWorld, 0.001f))
 					return slowHit;
 			}
 		}
-		while(spatialHash->getNextGrid(grid, unitRay, magnitude));
+		while (spatialHash->getNextGrid(grid, unitRay, magnitude));
 
 		return NULL;
 	}
@@ -166,14 +166,14 @@ namespace RBX
 		G3D::Ray worldRay = G3D::Ray::fromOriginAndDirection(originDirection.origin, maxSearchVec);
 		G3D::Array<Primitive const*> ignorePrims;
 
-		if(ignorePrim)
+		if (ignorePrim)
 			ignorePrims.push_back(ignorePrim);
 
 		Primitive* hit = getHit(worldRay, &ignorePrims, filter, hitPointWorld, ContactManager::ignoreBool);
 
 		float tempDist;
 
-		if(hit)
+		if (hit)
 		{
 			G3D::Vector3 temp = hitPointWorld - worldRay.origin;
 			tempDist = temp.magnitude();
@@ -197,14 +197,14 @@ namespace RBX
 		stopped = false;
 		inside = false;
 
-		for(int i = 0; i < primitives.size(); i++)
+		for (int i = 0; i < primitives.size(); i++)
 		{
 			Primitive* currentPrimitive = primitives[i];
 
 			bool isNotFound = ignorePrim ? ignorePrim->find(currentPrimitive) == ignorePrim->end() : true;
 			HitTestFilter::Result hitResult = filter ? filter->filterResult(currentPrimitive) : HitTestFilter::INCLUDE_PRIM;
 
-			if(isNotFound && hitResult != HitTestFilter::IGNORE_PRIM)
+			if (isNotFound && hitResult != HitTestFilter::IGNORE_PRIM)
 			{
 				G3D::Vector3 trans = currentPrimitive->getCoordinateFrame().translation;
 				float radius = currentPrimitive->getRadius();
@@ -212,26 +212,26 @@ namespace RBX
 				G3D::Vector3 math2 = trans - (unitRay.origin + unitRay.direction * math1);
 				float dist = math2.magnitude();
 
-				if(dist <= radius)
+				if (dist <= radius)
 				{
 					G3D::Vector3 thisHitPoint;
 					bool insideTemp;
-					if(currentPrimitive->hitTest(unitRay, thisHitPoint, insideTemp))
+					if (currentPrimitive->hitTest(unitRay, thisHitPoint, insideTemp))
 					{
 						float thisOffset = unitRay.direction.dot(thisHitPoint - unitRay.origin);
-						if(thisOffset > 0.0f)
+						if (thisOffset > 0.0f)
 						{
-							switch(hitResult)
+							switch (hitResult)
 							{
 							case HitTestFilter::STOP_TEST:
-								if(thisOffset < stopOffset)
+								if (thisOffset < stopOffset)
 								{
 									stopOffset = thisOffset;
 									stopped = true;
 								}
 								break;
 							case HitTestFilter::INCLUDE_PRIM:
-								if(thisOffset < bestOffset)
+								if (thisOffset < bestOffset)
 								{
 									inside = insideTemp;
 									bestOffset = thisOffset;
@@ -248,7 +248,7 @@ namespace RBX
 			}
 		}
 
-		if((stopped && bestPrimitive) && bestOffset < stopOffset)
+		if ((stopped && bestPrimitive) && bestOffset < stopOffset)
 			stopped = false;
 
 		return bestPrimitive;
@@ -259,17 +259,17 @@ namespace RBX
 		Geometry::GeometryType type0 = p0->getGeometry()->getGeometryType();
 		Geometry::GeometryType type1 = p1->getGeometry()->getGeometryType();
 
-		if(type0 > type1)
+		if (type0 > type1)
 			std::swap(p0, p1);
 
 		type0 = p0->getGeometry()->getGeometryType();
 		type1 = p1->getGeometry()->getGeometryType();
 
-		switch(type0)
+		switch (type0)
 		{
 		case Geometry::GEOMETRY_BALL:
 
-			switch(type1)
+			switch (type1)
 			{
 			case Geometry::GEOMETRY_BALL:
 				return new BallBallContact(p0, p1);

--- a/Client/App/v8world/JointStage.cpp
+++ b/Client/App/v8world/JointStage.cpp
@@ -55,7 +55,7 @@ namespace RBX
 	{
 		typedef std::multimap<Primitive*, Joint*>::const_iterator Iterator;
 
-		for(Iterator it = jointMap.lower_bound(p); it != jointMap.upper_bound(p); it++)
+		for (Iterator it = jointMap.lower_bound(p); it != jointMap.upper_bound(p); it++)
 		{
 			if (it->second == j)
 				return true;
@@ -77,12 +77,12 @@ namespace RBX
 	{
 		typedef std::multimap<Primitive*, Joint*>::iterator Iterator;
 
-		if(!p)
+		if (!p)
 			return;
 
 		RBXASSERT(pairInMap(j, p));
 
-		for(Iterator it = jointMap.lower_bound(p); it != jointMap.upper_bound(p); it++)
+		for (Iterator it = jointMap.lower_bound(p); it != jointMap.upper_bound(p); it++)
 		{
 			if (it->second == j) 
 			{
@@ -223,13 +223,13 @@ namespace RBX
 
 		std::vector<Joint*> jointsToPush;
 
-		for(Iterator it = jointMap.lower_bound(p); it != jointMap.upper_bound(p); it++)
+		for (Iterator it = jointMap.lower_bound(p); it != jointMap.upper_bound(p); it++)
 		{
-			if(edgeHasPrimitivesDownstream(it->second))
+			if (edgeHasPrimitivesDownstream(it->second))
 				jointsToPush.push_back(it->second);
 		}
 
-		for(size_t i = 0; i < jointsToPush.size(); i++)
+		for (size_t i = 0; i < jointsToPush.size(); i++)
 		{
 			Joint* current = jointsToPush[i];
 

--- a/Client/App/v8world/Primitive.cpp
+++ b/Client/App/v8world/Primitive.cpp
@@ -35,7 +35,7 @@ namespace RBX
 		JointK(this, &Primitive::computeJointK),
 		controller(NullController::getStaticNullController())
 	{
-		for(int i = 0; i < 6; i++) 
+		for (int i = 0; i < 6; i++) 
 		{
 			surfaceType[i] = NO_SURFACE;
 			surfaceData[i] = NULL;
@@ -47,12 +47,12 @@ namespace RBX
 	{
 		Geometry::GeometryType type = geometry->getGeometryType();
 
-		if(type != Geometry::GEOMETRY_NONE) {
+		if (type != Geometry::GEOMETRY_NONE) {
 			delete geometry;
 			delete body;
 		}
 
-		for(int i = 0; i < 6; i++)
+		for (int i = 0; i < 6; i++)
 			delete surfaceData[i];
 
 		RBXASSERT(!world);
@@ -63,7 +63,7 @@ namespace RBX
 	{
 		G3D::Vector3 r = newSize.min(G3D::Vector3(512.0f, 512.0f, 512.0f));
 
-		if(r.x * r.y * r.z > 1e+6f) 
+		if (r.x * r.y * r.z > 1e+6f) 
 		{
 			r.y = floorf(1e+6f / (r.x * r.z));
 		}
@@ -86,7 +86,7 @@ namespace RBX
 
 	void Primitive::setClump(Clump* set)
 	{
-		if(set != clump)
+		if (set != clump)
 		{
 			clump = set;
 		}
@@ -126,7 +126,7 @@ namespace RBX
 		G3D::Ray localRay = body->getPV().position.toObjectSpace(worldRay);
 		G3D::Vector3 localHitPoint;
 
-		if(geometry->hitTest(localRay, localHitPoint, inside))
+		if (geometry->hitTest(localRay, localHitPoint, inside))
 		{
 			worldHitPoint = body->getPV().position.pointToWorldSpace(localHitPoint);
 			return true;
@@ -151,26 +151,26 @@ namespace RBX
 
 	void Primitive::setSurfaceType(NormalId id, SurfaceType newSurfaceType)
 	{
-		if(surfaceType[id] != newSurfaceType)
+		if (surfaceType[id] != newSurfaceType)
 			surfaceType[id] = newSurfaceType;
 	}
 
 	void Primitive::setSurfaceData(NormalId id, const SurfaceData& newSurfaceData)
 	{
-		if(!surfaceData[id] && newSurfaceData.isEmpty())
+		if (!surfaceData[id] && newSurfaceData.isEmpty())
 			return;
 
-		if(surfaceData[id] && *surfaceData[id] == newSurfaceData)
+		if (surfaceData[id] && *surfaceData[id] == newSurfaceData)
 			return;
 
-		if(newSurfaceData.isEmpty())
+		if (newSurfaceData.isEmpty())
 		{
 			RBXASSERT(surfaceData[id]);
 			delete surfaceData[id];
 			surfaceData[id] = NULL;
 			return;
 		}
-		else if(!surfaceData[id])
+		else if (!surfaceData[id])
 		{
 			surfaceData[id] = new SurfaceData;
 		}
@@ -205,7 +205,7 @@ namespace RBX
 
 	Geometry* Primitive::newGeometry(Geometry::GeometryType geometryType)
 	{
-		switch(geometryType)
+		switch (geometryType)
 		{
 			case Geometry::GEOMETRY_BLOCK: return new Block;
 			case Geometry::GEOMETRY_BALL: return new Ball;
@@ -221,7 +221,7 @@ namespace RBX
 		RBXASSERT(clumpTouch);
 		RBXASSERT(clumpOTouch);
 
-		if(touch->getOwner()->reportTouches() && 
+		if (touch->getOwner()->reportTouches() && 
 			((!clumpTouch->getAnchored() && clumpTouch->getSleepStatus() == Sim::AWAKE) ||
 			(!clumpOTouch->getAnchored() && clumpOTouch->getSleepStatus() == Sim::AWAKE)))
 		{
@@ -245,15 +245,15 @@ namespace RBX
 		RBXASSERT(geometry->getGeometryType() != Geometry::GEOMETRY_NONE);
 		RBXASSERT(geometryType != Geometry::GEOMETRY_NONE);
 
-		if(geometry->getGeometryType() != geometryType)
+		if (geometry->getGeometryType() != geometryType)
 		{
 			G3D::Vector3 oldSize = geometry->getGridSize();
-			if(geometry)
+			if (geometry)
 				delete geometry;
 
 			geometry = newGeometry(geometryType);
 
-			if(world)
+			if (world)
 				world->onPrimitiveGeometryTypeChanged(this);
 
 			setGridSize(oldSize);
@@ -263,25 +263,25 @@ namespace RBX
 
 	void Primitive::setCoordinateFrame(const G3D::CoordinateFrame& value)
 	{
-		if(value != body->getPV().position)
+		if (value != body->getPV().position)
 		{
 			Assembly* assembly = getAssembly();
-			if(!assembly)
+			if (!assembly)
 			{
 				body->setCoordinateFrame(value);
 				myOwner->notifyMoved();
-				if(world)
+				if (world)
 					world->onPrimitiveExtentsChanged(this);
 			}
 			else
 			{
 				RBXASSERT(world);
-				if(assembly->getMainPrimitive() == this)
+				if (assembly->getMainPrimitive() == this)
 				{
 					body->setCoordinateFrame(value);
 					assembly->notifyMoved();
 					world->onAssemblyExtentsChanged(assembly);
-					if(!anchored)
+					if (!anchored)
 						world->ticklePrimitive(this);
 				}
 			}
@@ -290,16 +290,16 @@ namespace RBX
 
 	void Primitive::setDragging(bool _dragging)
 	{
-		if(dragging != _dragging)
+		if (dragging != _dragging)
 		{
 			bool oldDrag = !dragging && canCollide;
 			dragging = _dragging;
 
 			setAnchor(anchored);
-			if(world)
+			if (world)
 			{
 				bool newDrag = !dragging && canCollide;
-				if(newDrag != oldDrag)
+				if (newDrag != oldDrag)
 					world->onPrimitiveCanCollideChanged(this);
 			}
 		}
@@ -311,26 +311,26 @@ namespace RBX
 
 		bool exists = getAnchor();
 
-		if(_anchored || dragging)
+		if (_anchored || dragging)
 			_anchored = true;
 
-		if(_anchored == exists)
+		if (_anchored == exists)
 			return;
 
-		if(_anchored)
+		if (_anchored)
 		{
 			RBXASSERT(!anchorObject);
 			anchorObject = new Anchor(this);
-			if(world)
+			if (world)
 				world->onPrimitiveAddedAnchor(this);
 		}
 		else
 		{
 			RBXASSERT(anchorObject);
-			if(world)
+			if (world)
 				world->onPrimitiveRemovingAnchor(this);
 			
-			if(anchorObject)
+			if (anchorObject)
 				delete anchorObject;
 
 			anchorObject = NULL;
@@ -341,13 +341,13 @@ namespace RBX
 	{
 		bool oldDrag = !dragging && canCollide;
 
-		if(canCollide != value)
+		if (canCollide != value)
 		{
 			canCollide = value;
-			if(world)
+			if (world)
 			{
 				bool newDrag = !dragging && value;
-				if(oldDrag != newDrag)
+				if (oldDrag != newDrag)
 					world->onPrimitiveCanCollideChanged(this);
 			}
 		}
@@ -355,30 +355,30 @@ namespace RBX
 
 	void Primitive::setCanSleep(bool _canSleep)
 	{
-		if(_canSleep != canSleep)
+		if (_canSleep != canSleep)
 		{
 			canSleep = _canSleep;
-			if(world)
+			if (world)
 				world->onPrimitiveCanSleepChanged(this);
 		}
 	}
 
 	void Primitive::setFriction(float _friction)
 	{
-		if(_friction != friction)
+		if (_friction != friction)
 		{
 			friction = _friction;
-			if(world)
+			if (world)
 				world->onPrimitiveContactParametersChanged(this);
 		}
 	}
 
 	void Primitive::setElasticity(float _elasticity)
 	{
-		if(_elasticity != elasticity)
+		if (_elasticity != elasticity)
 		{
 			elasticity = _elasticity;
-			if(world)
+			if (world)
 				world->onPrimitiveContactParametersChanged(this);
 		}
 	}
@@ -387,7 +387,7 @@ namespace RBX
 	{
 		G3D::Vector3 protectedSize = clipToSafeSize(gridSize);
 
-		if(protectedSize != geometry->getGridSize())
+		if (protectedSize != geometry->getGridSize())
 		{
 			fuzzyExtentsStateId = -2;
 			geometry->setGridSize(protectedSize);
@@ -397,7 +397,7 @@ namespace RBX
 			body->setMoment(geometry->getMoment(newSize));
 			JointK.setDirty();
 
-			if(world)
+			if (world)
 				world->onPrimitiveExtentsChanged(this);
 
 			JointK.setDirty();
@@ -428,16 +428,16 @@ namespace RBX
 
 	void Primitive::setController(Controller* _controller)
 	{
-		if(!_controller)
+		if (!_controller)
 			_controller = NullController::getStaticNullController();
 
-		if(controller != _controller)
+		if (controller != _controller)
 			controller = _controller;
 	}
 
 	const Extents& Primitive::getFastFuzzyExtents() const
 	{
-		if(fuzzyExtentsStateId != body->getStateIndex())
+		if (fuzzyExtentsStateId != body->getStateIndex())
 		{
 			fuzzyExtents = computeFuzzyExtents();
 			fuzzyExtentsStateId = body->getStateIndex();
@@ -460,7 +460,7 @@ namespace RBX
 	{
 		Edge* next = e->getNext(this);
 
-		if(next)
+		if (next)
 			return next;
 		else
 			return Joint::isJoint(e) ? contacts.first : NULL;
@@ -470,9 +470,9 @@ namespace RBX
 	{
 		Primitive* least = p0->getNumJoints2() < p1->getNumJoints2() ? p0 : p1;
 
-		for(Joint* current = least->getFirstJoint(); current != NULL; current = least->getNextJoint(current))
+		for (Joint* current = least->getFirstJoint(); current != NULL; current = least->getNextJoint(current))
 		{
-			if(p0 == current->getPrimitive(0) && p1 == current->getPrimitive(1) || p0 == current->getPrimitive(1) && p1 == current->getPrimitive(0))
+			if (p0 == current->getPrimitive(0) && p1 == current->getPrimitive(1) || p0 == current->getPrimitive(1) && p1 == current->getPrimitive(0))
 			   return current;
 		}
 		return NULL;
@@ -482,9 +482,9 @@ namespace RBX
 	{
 		Primitive* least = p0->getNumContacts() < p1->getNumContacts() ? p0 : p1;
 
-		for(Contact* current = least->getFirstContact(); current != NULL; current = least->getNextContact(current))
+		for (Contact* current = least->getFirstContact(); current != NULL; current = least->getNextContact(current))
 		{
-			if(p0 == current->getPrimitive(0) && p1 == current->getPrimitive(1) || p0 == current->getPrimitive(1) && p1 == current->getPrimitive(0))
+			if (p0 == current->getPrimitive(0) && p1 == current->getPrimitive(1) || p0 == current->getPrimitive(1) && p1 == current->getPrimitive(0))
 			   return current;
 		}
 		return NULL;
@@ -492,9 +492,9 @@ namespace RBX
 
 	RigidJoint* Primitive::getFirstRigidAt(Edge* start)
 	{
-		for(Edge* current = start; current != NULL; current = getNextEdge(current))
+		for (Edge* current = start; current != NULL; current = getNextEdge(current))
 		{
-			if(RigidJoint::isRigidJoint(current))
+			if (RigidJoint::isRigidJoint(current))
 				return rbx_static_cast<RigidJoint*>(current);
 		}
 		return NULL;
@@ -503,10 +503,10 @@ namespace RBX
 	int Primitive::countNumJoints() const
 	{
 		int counter = 0;
-		for(Joint* current = getFirstJoint(); current != NULL; current = getNextJoint(current))
+		for (Joint* current = getFirstJoint(); current != NULL; current = getNextJoint(current))
 		{
 			Joint::JointType type = current->getJointType();
-			if(type != Joint::FREE_JOINT && type != Joint::ANCHOR_JOINT)
+			if (type != Joint::FREE_JOINT && type != Joint::ANCHOR_JOINT)
 				counter++;
 		}
 		return counter;
@@ -517,11 +517,11 @@ namespace RBX
 		Primitive* p0 = e->getPrimitive(0);
 		Primitive* p1 = e->getPrimitive(1);
 
-		if(Joint::isJoint(e))
+		if (Joint::isJoint(e))
 		{
 			EdgeList::insertEdge(p0, e, e->getPrimitive(0)->joints);
 
-			if(p1)
+			if (p1)
 				EdgeList::insertEdge(p1, e, e->getPrimitive(1)->joints);
 			else
 				RBXASSERT(rbx_static_cast<Joint*>(e)->getJointType() == Joint::ANCHOR_JOINT || rbx_static_cast<Joint*>(e)->getJointType() == Joint::FREE_JOINT);
@@ -538,11 +538,11 @@ namespace RBX
 		Primitive* p0 = e->getPrimitive(0);
 		Primitive* p1 = e->getPrimitive(1);
 
-		if(Joint::isJoint(e))
+		if (Joint::isJoint(e))
 		{
 			EdgeList::removeEdge(p0, e, e->getPrimitive(0)->joints);
 
-			if(p1)
+			if (p1)
 				EdgeList::removeEdge(p1, e, e->getPrimitive(1)->joints);
 			else
 				RBXASSERT(rbx_static_cast<Joint*>(e)->getJointType() == Joint::ANCHOR_JOINT || rbx_static_cast<Joint*>(e)->getJointType() == Joint::FREE_JOINT);
@@ -563,15 +563,15 @@ namespace RBX
 
 	void EdgeList::removeEdge(Primitive* p, Edge* e, EdgeList& list)
 	{
-		if(list.first == e)
+		if (list.first == e)
 		{
-			list.first = list.first->getNext(p);
+			list.first = e->getNext(p);
 		}
 		else
 		{
 			Edge* currentEdge = list.first;
 
-			while(currentEdge->getNext(p) != e)
+			while (currentEdge->getNext(p) != e)
 			{
 				currentEdge = currentEdge->getNext(p);
 			}

--- a/Client/App/v8world/SpatialHash.cpp
+++ b/Client/App/v8world/SpatialHash.cpp
@@ -33,7 +33,7 @@ namespace RBX
 		{
 			if (this->nodes[i])
 			{
-				while(this->nodes[i])
+				while (this->nodes[i])
 				{
 					SpatialNode* backup = this->nodes[i];
 					this->nodes[i] = this->nodes[i]->nextHashLink;
@@ -43,7 +43,7 @@ namespace RBX
 			}
 		}
 
-		while(this->extraNodes)
+		while (this->extraNodes)
 		{
 			SpatialNode* node = this->extraNodes;
 			this->extraNodes = node->nextHashLink;

--- a/Client/App/v8world/World.cpp
+++ b/Client/App/v8world/World.cpp
@@ -238,10 +238,10 @@ namespace RBX
 		assertNotInStep();
 
 		std::set<Primitive*> ignore;
-		for(int i = 0; i < primitives.size(); i++)
+		for (int i = 0; i < primitives.size(); i++)
 			ignore.insert(primitives[i]);
 
-		for(int i = 0; i < primitives.size(); i++)
+		for (int i = 0; i < primitives.size(); i++)
 			createJoints(primitives[i], &ignore);
 	}
 
@@ -250,10 +250,10 @@ namespace RBX
 		assertNotInStep();
 
 		std::set<Primitive*> ignore;
-		for(int i = 0; i < primitives.size(); i++)
+		for (int i = 0; i < primitives.size(); i++)
 			ignore.insert(primitives[i]);
 
-		for(int i = 0; i < primitives.size(); i++)
+		for (int i = 0; i < primitives.size(); i++)
 			destroyJoints(primitives[i], &ignore);
 	}
 
@@ -289,7 +289,7 @@ namespace RBX
 
 	void World::removeFromBreakable(Joint* j)
 	{
-		if(j->isBreakable())
+		if (j->isBreakable())
 		{
 			size_t success = breakableJoints.erase(j);
 			RBXASSERT(success == 1);
@@ -310,7 +310,7 @@ namespace RBX
 
 	void World::joinAll()
 	{
-		for(int i = 0; i < primitives.size(); i++)
+		for (int i = 0; i < primitives.size(); i++)
 			createJoints(primitives[i]);
 	}
 
@@ -359,17 +359,17 @@ namespace RBX
 
 		const SleepStage* sStage = rbx_static_cast<SleepStage*>(jointStage->findStage(IStage::SLEEP_STAGE)); // World::getSleepStage()
 
-		for(Iter cIt = sStage->getAwakeAssemblies().begin(); cIt != sStage->getAwakeAssemblies().end(); cIt++)
+		for (Iter cIt = sStage->getAwakeAssemblies().begin(); cIt != sStage->getAwakeAssemblies().end(); cIt++)
 		{
 			const Assembly* current = *cIt;
-			if(current->getMainPrimitive()->getCoordinateFrame().translation.y < -500.0f)
+			if (current->getMainPrimitive()->getCoordinateFrame().translation.y < -500.0f)
 			{
 				Assembly::PrimIterator it = Assembly::PrimIterator::begin(current);
 				Assembly::PrimIterator pEnd = Assembly::PrimIterator::end(current);
-				for(; it != pEnd; ++it)
+				for (; it != pEnd; ++it)
 				{
 					Primitive* currentPrim = *it;
-					if(currentPrim->getCoordinateFrame().translation.y < -500.0f)
+					if (currentPrim->getCoordinateFrame().translation.y < -500.0f)
 						fallen.push_back(currentPrim);
 				}
 			}

--- a/Client/App/v8xml/SerializerV2.cpp
+++ b/Client/App/v8xml/SerializerV2.cpp
@@ -37,7 +37,7 @@ namespace RBX
 		InstanceHandle h;
 		if (valueIDREF->getValue(h))
 		{
-			if(!h.empty())
+			if (!h.empty())
 				idref->assignIDREF(propertyOwner, h);
 			else
 			{
@@ -87,7 +87,7 @@ bool ArchiveBinder::resolveIDREF(IDREFBinding binding)
 	RBXASSERT(s != "");
 
 	std::map<std::string, RBX::InstanceHandle>::iterator found = idMap.find(s);
-	if(found != idMap.end())
+	if (found != idMap.end())
 	{
 		RBX::InstanceHandle& foundHandle = found->second;
 		binding.idref->assignIDREF(binding.propertyOwner,foundHandle);
@@ -118,7 +118,7 @@ bool ArchiveBinder::processID(const XmlNameValuePair* valueID, RBX::Instance* so
 
 bool ArchiveBinder::processIDREF(const XmlNameValuePair* valueIDREF, RBX::Reflection::DescribedBase* propertyOwner, const RBX::IIDREF* idref)
 {
-	if(!MergeBinder::processIDREF(valueIDREF, propertyOwner, idref))
+	if (!MergeBinder::processIDREF(valueIDREF, propertyOwner, idref))
 	{
 		IDREFBinding binding = {valueIDREF, propertyOwner, idref};
 		idrefBindings.push_back(binding);
@@ -133,10 +133,10 @@ void isolate(XmlElement* element, const std::map<RBX::Instance*, RBX::InstanceHa
 {
 	element->replaceHandles(isolationMap);
 
-	for(XmlAttribute* attr = element->getFirstAttribute(); attr != NULL; attr = element->getNextAttribute(attr))
+	for (XmlAttribute* attr = element->getFirstAttribute(); attr != NULL; attr = element->getNextAttribute(attr))
 		attr->replaceHandles(isolationMap);
 
-	for(XmlElement* elem = element->firstChild(); elem != NULL; elem = element->nextChild(elem))
+	for (XmlElement* elem = element->firstChild(); elem != NULL; elem = element->nextChild(elem))
 		isolate(elem, isolationMap);
 }
 

--- a/Client/App/v8xml/XmlElement.cpp
+++ b/Client/App/v8xml/XmlElement.cpp
@@ -46,7 +46,7 @@ const RBX::Name& tag_xsinoNamespaceSchemaLocation = RBX::Name::declare("xsi:noNa
 
 void XmlNameValuePair::clearValue() const
 {
-	switch(valueType)
+	switch (valueType)
 	{
 	case HANDLE:
 		delete handleValue;
@@ -260,7 +260,7 @@ bool XmlNameValuePair::isValueType<std::string>() const
 
 bool XmlNameValuePair::isValueEqual(const RBX::Name* value) const
 {
-	switch(valueType)
+	switch (valueType)
 	{
 	case NAME:
 		return value == nameValue;
@@ -314,11 +314,11 @@ void XmlNameValuePair::replaceHandles(const std::map<RBX::Instance*, RBX::Instan
 {
 	typedef std::map<RBX::Instance*, RBX::InstanceHandle>::const_iterator Iter;
 
-	if(valueType == HANDLE)
+	if (valueType == HANDLE)
 	{
 		Iter r = isolationMap.find(handleValue->getTarget().get());
 
-		if(r != isolationMap.end())
+		if (r != isolationMap.end())
 		{
 			*handleValue = r->second;
 		}


### PR DESCRIPTION
Cleaned up some older code, including my own:

- Several match improvements, including:
  - Clump::onPrimitiveCanSleepChanged, Clump::computeCanSleep 100%
  - EdgeList::removeEdge 90% -> 92%, was not functionally accurate before
  - ClumpStage::getMotorPower 100%
 
- Added spaces after every for/while/if/switch statement that doesn't have them already for consistency with the rest of the codebase