### PR TITLE
hotfix: redefinition errors (?)

### DIFF
--- a/Client/App/include/util/Profiling.h
+++ b/Client/App/include/util/Profiling.h
@@ -1,8 +1,7 @@
 #pragma once
-#include <windows.h>
+#include <G3D/Vector3.h>
 #include <boost/noncopyable.hpp>
 #include <string>
-#include <g3d/g3dmath.h>
 
 namespace RBX
 {

--- a/Client/Network/Client.cpp
+++ b/Client/Network/Client.cpp
@@ -1,7 +1,8 @@
-#include "util/standardout.h"
+#include <RakNetTypes.h>
+#include <RakPeer.h>
 #include "API.h"
 #include "Client.h"
-#include <RakNetTypes.h>
+#include "util/standardout.h"
 
 const char* Exposer::IDTOString(int id)
 {

--- a/Client/Network/Client.h
+++ b/Client/Network/Client.h
@@ -1,8 +1,7 @@
 #pragma once
-#include <winsock2.h>
-#include "reflection/signal.h"
-#include "v8xml/XmlElement.h"
+#include <PacketLogger.h>
 #include "Replicator.h"
+#include "reflection/signal.h"
 #include <boost/shared_ptr.hpp>
 #include <string>
 
@@ -13,6 +12,8 @@ public:
 
 	static const char* IDTOString(int id);
 };
+
+class XmlElement;
 
 namespace RBX
 {

--- a/Client/Network/Player.cpp
+++ b/Client/Network/Player.cpp
@@ -1,5 +1,5 @@
-#include "Player.h"
 #include "Client.h"
+#include "Player.h"
 #include "v8datamodel/TimerService.h"
 
 namespace RBX

--- a/Client/Network/Players.cpp
+++ b/Client/Network/Players.cpp
@@ -1,5 +1,7 @@
-#include "Players.h"
+#include <RakPeer.h>
+#include <BitStream.h>
 #include "Client.h"
+#include "Players.h"
 #include "Streaming.h"
 
 template<class Class>

--- a/Client/Network/Replicator.cpp
+++ b/Client/Network/Replicator.cpp
@@ -1,3 +1,5 @@
+#include <RakPeer.h>
+#include <PacketLogger.h>
 #include "Replicator.h"
 #include <g3d/system.h>
 

--- a/Client/Network/Replicator.h
+++ b/Client/Network/Replicator.h
@@ -1,15 +1,14 @@
 #pragma once
-#include <winsock2.h>
-#include "v8tree/Instance.h"
-#include "v8tree/Service.h"
+#include <PluginInterface.h>
+#include "util/RunStateOwner.h"
 #include "util/Events.h"
 #include "util/Profiling.h"
-#include "util/RunStateOwner.h"
-#include <PacketLogger.h>
-#include <PluginInterface.h>
-#include <RakPeer.h>
-#include <RakPeerInterface.h>
 #include <boost/scoped_ptr.hpp>
+
+class RakPeer;
+class RakPeerInterface;
+
+class PacketLogger;
 
 namespace RBX
 {

--- a/Client/Network/Streaming.cpp
+++ b/Client/Network/Streaming.cpp
@@ -1,6 +1,6 @@
-#include "Streaming.h"
 #include <BitStream.h>
 #include <StringCompressor.h>
+#include "Streaming.h"
 #include <algorithm>
 
 namespace RBX

--- a/Client/Network/Streaming.h
+++ b/Client/Network/Streaming.h
@@ -4,12 +4,16 @@
 #include "util/Name.h"
 #include "util/Guid.h"
 #include "reflection/property.h"
-#include <BitStream.h>
 #include <g3d/CoordinateFrame.h>
 #include <boost/shared_ptr.hpp>
 #include <boost/noncopyable.hpp>
 #include <map>
 #include <string>
+
+namespace RakNet
+{
+	class BitStream;
+}
 
 namespace RBX
 {

--- a/Client/Network/include/Network/Player.h
+++ b/Client/Network/include/Network/Player.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <winsock2.h>
 #include "Network/Players.h"
 #include "security/SecurityContext.h"
 #include "humanoid/Humanoid.h"


### PR DESCRIPTION
*Should* resolve #127, at least for now.

RakNet requires that windows.h be included AFTER anything from RakNet; otherwise, redefinition errors occur. This means that anything from G3D must be included after RakNet, since practically every header in G3D includes platform.h, which includes windows.h.

Might cause conflicts with other PRs.